### PR TITLE
Bump satysfi version of satysfi-lib-dist.0.0.3+dev2019.03.10

### DIFF
--- a/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.03.10/opam
@@ -46,7 +46,7 @@ remove: [
   ["rm" "-rf" "%{share}%/satysfi/dist"]
 ]
 depends: [
-  "satysfi" {= "0.0.3+dev2019.02.13" }
+  "satysfi" {= "0.0.3+dev2019.03.10" }
 ]
 synopsis: "Standard library of SATySFi"
 description: """


### PR DESCRIPTION
Hi! Thank you for the very useful repo!

I can't install `satysfi.0.0.3+dev2019.03.10` and `satysfi-lib-dist.0.0.3+dev2019.03.10` together because `satysfi-lib-dist.0.0.3+dev2019.03.10` depends on `satysfi.0.0.3+dev2019.02.13`.
I think it should be `0.0.3+dev2019.03.10`.
