### PR TITLE
Package satysfi-karnaugh.0.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ env:
       satysfi-fonts-theano-doc
       satysfi-grcnum
       satysfi-grcnum-doc
+      satysfi-karnaugh
+      satysfi-karnaugh-doc
       satysfi-make-html
       satysfi-make-markdown
       satysfi-matrix

--- a/packages/satysfi-karnaugh-doc/satysfi-karnaugh-doc.0.0.1/opam
+++ b/packages/satysfi-karnaugh-doc/satysfi-karnaugh-doc.0.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:     "Document: Drawing Karnaugh maps in SATySFi"
+description:  """
+Document: Drawing Karnaugh maps in SATySFi
+
+This can be installed as a package for SATySFi by Satyrographos. (https://github.com/na4zagin3/satyrographos) 
+"""
+maintainer:   "takagiy <takagiy.4dev@gmail.com>"
+authors:      "takagiy <takagiy.4dev@gmail.com>"
+homepage:     "https://github.com/takagiy/satysfi-karnaugh"
+bug-reports:  "https://github.com/takagiy/satysfi-karnaugh/issues"
+dev-repo:     "git+https://github.com/takagiy/satysfi-karnaugh.git"
+license:      "MIT"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-karnaugh" {= "0.0.1"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "karnaugh-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "karnaugh-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  git: "git+https://github.com/takagiy/satysfi-karnaugh.git#ed38a3ec2afa09a383a2b4e9068ece4dd9bba715"
+}

--- a/packages/satysfi-karnaugh/satysfi-karnaugh.0.0.1/opam
+++ b/packages/satysfi-karnaugh/satysfi-karnaugh.0.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis:     "Drawing Karnaugh maps in SATySFi"
+description:  """
+Drawing Karnaugh maps in SATySFi
+
+This can be installed as a package for SATySFi by Satyrographos. (https://github.com/na4zagin3/satyrographos) 
+"""
+maintainer:   "takagiy <takagiy.4dev@gmail.com>"
+authors:      "takagiy <takagiy.4dev@gmail.com>"
+homepage:     "https://github.com/takagiy/satysfi-karnaugh"
+bug-reports:  "https://github.com/takagiy/satysfi-karnaugh/issues"
+dev-repo:     "git+https://github.com/takagiy/satysfi-karnaugh.git"
+license:      "MIT"
+depends: [
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: []
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "karnaugh"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  git: "git+https://github.com/takagiy/satysfi-karnaugh.git#ed38a3ec2afa09a383a2b4e9068ece4dd9bba715"
+}


### PR DESCRIPTION
### `satysfi-karnaugh.0.0.1`
Drawing Karnaugh maps in SATySFi
Drawing Karnaugh maps in SATySFi

This can be installed as a package for SATySFi by Satyrographos. (https://github.com/na4zagin3/satyrographos)



---
* Homepage: https://github.com/takagiy/satysfi-karnaugh
* Source repo: git+https://github.com/takagiy/satysfi-karnaugh.git
* Bug tracker: https://github.com/takagiy/satysfi-karnaugh/issues

---
:camel: Pull-request generated by opam-publish v2.0.0

---

Closes #18