### PR TITLE
Add satysfi.0.0.3+dev2019.11.16 and satysfi-lib-dist.0.0.3+dev2019.11.16

### DIFF
--- a/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/files/fix-install-libs.patch
+++ b/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/files/fix-install-libs.patch
@@ -1,0 +1,12 @@
+diff --git a/install-libs.sh b/install-libs.sh
+index 49fdd16..9c7dd11 100755
+--- a/install-libs.sh
++++ b/install-libs.sh
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-LIBDIR=/usr/local/share/satysfi
++LIBDIR=${1:-/usr/local/share/satysfi}
+ 
+ install -d ${LIBDIR}
+ install -d ${LIBDIR}/dist

--- a/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+name: "satysfi-lib-dist"
+version: "0.0.3+dev2019.11.16"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "gfngfn"
+]
+extra-source "temp/lm2.004otf.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  checksum: [
+    "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
+    "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
+  ]
+}
+extra-source "temp/latinmodern-math-1959.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  checksum: [
+    "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
+    "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"
+  ]
+}
+extra-source "temp/junicode-1.002.zip" {
+  archive: "http://downloads.sourceforge.net/project/junicode/junicode/junicode-1.002/junicode-1.002.zip"
+  checksum: [
+    "sha256=c199d96c8424be60fcab8d00d2eee39ea8ae632cfd5e710cbbd70626d6a729e7"
+    "sha512=1738802f70b0029567be608ed36481864f8f7f029fd1c45d73fa25d092d49c978c51df1c01147b7b176e9b0409d7f15d5713a6daf1b1b269636bc6324b2c6f37"
+  ]
+}
+extra-source "temp/IPAexfont00301.zip" {
+  archive: "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  checksum: [
+    "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
+    "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"
+  ]
+}
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["./download-fonts.sh"]
+]
+install: [
+  ["./install-libs.sh" "%{share}%/satysfi"]
+]
+remove: [
+  ["rm" "-rf" "%{share}%/satysfi/dist"]
+]
+depends: [
+  "satysfi" {= "0.0.3+dev2019.11.16" }
+]
+synopsis: "Standard library of SATySFi"
+description: """
+Provides the standard library of SATySFi"""
+extra-files: ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
+patches: ["fix-install-libs.patch"]
+url {
+  git: "git+https://github.com/gfngfn/SATySFi.git#69e62f66056b5644461f73c5fe841003602b0938"
+}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "satysfi"
+version: "0.0.3+dev2019.11.16"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "gfngfn"
+]
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["mkdir" "-p" "temp"]
+  [make "-f" "Makefile" "PREFIX=%{prefix}%"]
+]
+install: [
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%"]
+]
+# Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "batteries"
+  "camlimages" {>= "5.0.1"}
+  "camlpdf" {= "2.2.2+satysfi"}
+  "core_kernel" {>= "v0.10.0"}
+  "cppo" {build & >= "1.6.4" & < "1.7.0"}
+  "depext"
+  "dune" {build}
+  "menhir"
+  "ocamlfind" {build}
+  "otfm" {= "0.3.7+satysfi"}
+  "ppx_deriving"
+  "re" {build}
+  "uutf"
+  "yojson" {= "1.4.1+satysfi"}
+  "omd"
+]
+synopsis: "A statically-typed, functional typesetting system"
+description: """
+SATySFi is a typesetting system with a static type system. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has ML-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""
+url {
+  git: "git+https://github.com/gfngfn/SATySFi.git#69e62f66056b5644461f73c5fe841003602b0938"
+}


### PR DESCRIPTION
I've added current snapshot of SATySFi because I want a fix of otfm (https://github.com/gfngfn/otfm/pull/7).



<details>
<summary>diff from previous snapshot (0.0.3+dev2019.07.14)</summary>

```
❯ diff -u satysfi/satysfi.0.0.3+dev2019.07.14/opam satysfi/satysfi.0.0.3+dev2019.11.16/opam
--- satysfi/satysfi.0.0.3+dev2019.07.14/opam    2019-11-16 13:31:17.000000000 +0900
+++ satysfi/satysfi.0.0.3+dev2019.11.16/opam    2019-11-16 16:31:23.000000000 +0900
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi"
-version: "0.0.3+dev2019.07.14"
+version: "0.0.3+dev2019.11.16"
 maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
 authors: [
   "gfngfn"
@@ -30,7 +30,7 @@
   "dune" {build}
   "menhir"
   "ocamlfind" {build}
-  "otfm" {= "0.3.6+satysfi"}
+  "otfm" {= "0.3.7+satysfi"}
   "ppx_deriving"
   "re" {build}
   "uutf"
@@ -41,5 +41,5 @@
 description: """
 SATySFi is a typesetting system with a static type system. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has ML-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""
 url {
-  git: "git+https://github.com/gfngfn/SATySFi.git#b1349fae80e43ac454bbcd9a7101c9988fe6aaa2"
+  git: "git+https://github.com/gfngfn/SATySFi.git#69e62f66056b5644461f73c5fe841003602b0938"
 }


❯ diff -u satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.07.14/opam satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam
--- satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.07.14/opam  2019-11-16 13:29:10.000000000 +0900
+++ satysfi-lib-dist/satysfi-lib-dist.0.0.3+dev2019.11.16/opam  2019-11-16 16:31:23.000000000 +0900
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-lib-dist"
-version: "0.0.3+dev2019.07.14"
+version: "0.0.3+dev2019.11.16"
 maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
 authors: [
   "gfngfn"
@@ -27,7 +27,7 @@
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"
@@ -46,7 +46,7 @@
   ["rm" "-rf" "%{share}%/satysfi/dist"]
 ]
 depends: [
-  "satysfi" {= "0.0.3+dev2019.07.14" }
+  "satysfi" {= "0.0.3+dev2019.11.16" }
 ]
 synopsis: "Standard library of SATySFi"
 description: """
@@ -54,5 +54,5 @@
 extra-files: ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
 patches: ["fix-install-libs.patch"]
 url {
-  git: "git+https://github.com/gfngfn/SATySFi.git#b1349fae80e43ac454bbcd9a7101c9988fe6aaa2"
+  git: "git+https://github.com/gfngfn/SATySFi.git#69e62f66056b5644461f73c5fe841003602b0938"
 }
```
</details>