### PR TITLE
Packages satysfi-class-stjarticle.1.3.2 and satysfi-class-stjarticle-doc.1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     satyrographos=0.0.2.1
     satysfi-class-exdesign
     satysfi-class-exdesign-doc
+    satysfi-class-stjarticle
+    satysfi-class-stjarticle-doc
     satysfi-fonts-theano
     satysfi-fonts-theano-doc
     satysfi-grcnum

--- a/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Document: Extended SATySFi document package for Japanese"
+description: """
+Document: Extended SATySFi document package for Japanese.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "LGPL-3.0"
+homepage: "https://github.com/puripuri2100/stjarticle"
+bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
+dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-stjarticle" {= "1.3.2"}
+  "satysfi-lib-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-stjarticle-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-stjarticle-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-stjarticle-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  git: "git+https://github.com/puripuri2100/stjarticle.git#9381bee930818464e76cdc4622eb381a1aba164f"
+}

--- a/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Extended SATySFi document package for Japanese"
+description: """
+Extended SATySFi document package for Japanese.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "LGPL-3.0"
+homepage: "https://github.com/puripuri2100/stjarticle"
+bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
+dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.1" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-stjarticle"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-stjarticle"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  git: "git+https://github.com/puripuri2100/stjarticle.git#9381bee930818464e76cdc4622eb381a1aba164f"
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-stjarticle.1.3.2`: Extended SATySFi document package for Japanese
-`satysfi-class-stjarticle-doc.1.3.2`: Document: Extended SATySFi document package for Japanese



---
* Homepage: https://github.com/puripuri2100/stjarticle
* Source repo: git+https://github.com/puripuri2100/stjarticle.git
* Bug tracker: https://github.com/puripuri2100/stjarticle/issues

---
:camel: Pull-request generated by opam-publish v2.0.0