### PR TITLE
Restrict core_kernel version for SATySFi

### DIFF
--- a/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
@@ -59,7 +59,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.1+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.02.10/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.02.10/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.02.13/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.02.13/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.03.10/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.07.14/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.07.14/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/packages/satysfi/satysfi.0.0.3/opam
+++ b/packages/satysfi/satysfi.0.0.3/opam
@@ -59,7 +59,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.1+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}


### PR DESCRIPTION
See https://github.com/gfngfn/SATySFi/pull/206 for details.

Related: https://github.com/amutake/satysfi-docker/pull/9