### PR TITLE
Package satysfi-base.1.0.0

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.0.0/opam
+++ b/packages/satysfi-base/satysfi-base.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos."""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+install: [
+  "satyrographos"
+  "opam"
+  "install"
+  "-name"
+  "base"
+  "-prefix"
+  "%{prefix}%"
+  "-script"
+  "%{build}%/Satyristes"
+]
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+url {
+  src: "https://github.com/nyuichi/satysfi-lib/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=e526464d4d472a1c2f18315c060aa649"
+    "sha512=5e66dce6542f19f27fbc42ade8755f82ffbde42d1981c81a49c0de2ede26bace3522fef763538efeed2aaa18ce1d3910f2bb14723e30ca1290c1ad86595b27eb"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.0.0`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0