### PR TITLE
Package satysfi-base.1.1.1

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.1.1/opam
+++ b/packages/satysfi-base/satysfi-base.1.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "base"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/nyuichi/satysfi-lib/archive/1.1.1.tar.gz"
+  checksum: [
+    "md5=898a13adff663d2023f58b23213ec0aa"
+    "sha512=a07a3deb55aed4d24d4216dca629a328f99516f9a3fbe6d72800ca29931e8521935164ca418f94a494c1f9824a210c5418da56fdcf41549994fc3463177af28d"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.1.1`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0