### PR TITLE
Packages satysfi-fonts-dejavu.2.37 and satysfi-fonts-dejavu-doc.2.0

### DIFF
--- a/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.0/opam
+++ b/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for DejaVu Fonts"
+description: """
+SATySFi font package for DejaVu fonts.
+
+This package installs fonts from https://dejavu-fonts.github.io/.
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "Murase Yuito <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-dejavu"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-dejavu/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-dejavu.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-dejavu"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-dejavu-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-dejavu-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "fonts-dejavu-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]

--- a/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37/opam
+++ b/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for DejaVu Fonts"
+description: """
+SATySFi font package for DejaVu fonts.
+
+This package installs fonts from https://dejavu-fonts.github.io/.
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-dejavu"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-dejavu/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-dejavu.git"
+extra-source "dejavu-fonts-ttf-2.37.zip" {
+  archive: "http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.zip"
+  checksum: [
+    "sha256=7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a"
+    "sha512=f5628efe484b6220d0bf8177aa826c28e7a36f0bcca2019e057c20f5915d579057f931377ec686dbfeebef05fcf6453472be77a21ef282bd9d8d0eaf62549a49"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "dejavu" "-o" "dejavu-fonts-ttf-2.37.zip" "*.ttf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-dejavu"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-dejavu.2.37`: SATySFi Font Package for DejaVu Fonts
-`satysfi-fonts-dejavu-doc.2.0`: Document of SATySFi Font Package for DejaVu
 Fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-dejavu
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-dejavu.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-dejavu/issues

---
:camel: Pull-request generated by opam-publish v2.0.0