### PR TITLE
Remove duplicate url in satysfi.0.0.4

### DIFF
--- a/packages/satysfi/satysfi.0.0.4/opam
+++ b/packages/satysfi/satysfi.0.0.4/opam
@@ -41,9 +41,6 @@ synopsis: "A statically-typed, functional typesetting system"
 description: """
 SATySFi is a typesetting system with a static type system. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has ML-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""
 url {
-  git: "git+https://github.com/gfngfn/SATySFi.git#69e62f66056b5644461f73c5fe841003602b0938"
-}
-url {
   src: "https://github.com/gfngfn/SATySFi/archive/v0.0.4.tar.gz"
   checksum: [
     "sha512=c1192ed795df433b7cae12e90bcf3f1df7af3f7cad0d16a93c7ba392b2734bc02d5b3a9bea09f8c9806d527cbbed5b310b17fe58ae2f431cde0684be512ea21a"


### PR DESCRIPTION
I've noticed that url section in opam file of satysfi.0.0.4 is duplicated.
(This git hash points to satysfi.0.0.3+dev2019.11.16)