### PR TITLE
2 packages from zeptometer/SATySFi-fonts-asana at 2.37+satysfi0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     satysfi-class-stjarticle-doc
     satysfi-class-slydifi
     satysfi-base
+    satysfi-fonts-asana-math
+    satysfi-fonts-asana-math-doc
     satysfi-fonts-dejavu
     satysfi-fonts-dejavu-doc
     satysfi-fonts-theano

--- a/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.2.37+satysfi0.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Asana Math Fonts"
+description: """
+Document package for satysfi-fonts-asana-math
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-asana-math" {= "2.37+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-asana-math-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-asana-math-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-asana/archive/2.37+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=176d16a041c0d177b114474ec4af644e"
+    "sha512=02e268432513761169857da30157545b2e6f4fb9798e473c8fdbd3baca87f31edd4fbf99b5f7e060a040200ad49f02e75e7d8731abd1a7ced9cd2557c47575e5"
+  ]
+}

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.2.37+satysfi0.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Asana Math Fonts"
+description: """
+SATySFi font package for Asana Math fonts.
+
+This package installs fonts from http://mirrors.ctan.org/fonts/Asana-Math/.
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
+extra-source "Asana-Math.otf" {
+  archive: "http://mirrors.ctan.org/fonts/Asana-Math/Asana-Math.otf"
+  checksum: [
+    "sha256=b0d9e681c08ff1f4dc6ebf085cc962585ec12cdbd25dc6225890b9f8fd12d568"
+    "sha512=caedaf8dbbdc914a41492605b1ac69b020297bffa8a968e424f758d4aadb0c6391c71ed48b1645bc12eb1820a72d88425a0d2dfbd528c5071566284ad4f5f1b3"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-asana-math"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-asana/archive/2.37+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=176d16a041c0d177b114474ec4af644e"
+    "sha512=02e268432513761169857da30157545b2e6f4fb9798e473c8fdbd3baca87f31edd4fbf99b5f7e060a040200ad49f02e75e7d8731abd1a7ced9cd2557c47575e5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-asana-math.2.37+satysfi0.0.4`: SATySFi Font Package for Asana Math Fonts
-`satysfi-fonts-asana-math-doc.2.37+satysfi0.0.4`: Document of SATySFi Font Package for Asana Math Fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-asana-math
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-asana-math/issues

---
:camel: Pull-request generated by opam-publish v2.0.2