### PR TITLE
Specify a mirror of IPAexfont00301.zip

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4/opam
@@ -28,6 +28,9 @@ extra-source "temp/junicode-1.002.zip" {
 }
 extra-source "temp/IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
@@ -31,6 +31,9 @@ extra-source "junicode-1.002.zip" {
 }
 extra-source "IPAexfont00301.zip" {
   archive: "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"

--- a/packages/satysfi/satysfi.0.0.3/opam
+++ b/packages/satysfi/satysfi.0.0.3/opam
@@ -31,6 +31,9 @@ extra-source "junicode-1.002.zip" {
 }
 extra-source "IPAexfont00301.zip" {
   archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
+  ]
   checksum: [
     "sha256=c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a"
     "sha512=92df9f6a1002ea68cfd88f2b1fe4a5a5d6dfdb0ac4be7f4c0815200ce1962d3db7330ec17e7380efe4ba0735a55e0f5160b0cd6c1553a79fc8a860c434958388"


### PR DESCRIPTION
I uploaded fonts used by satysfi-dist to https://github.com/na4zagin3/satysfi-dist-font-archives

This PR it to specify the mirror URL of IPAexfont00301.zip.