### PR TITLE
Package satysfi-base.1.2.0

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.2.0/opam
+++ b/packages/satysfi-base/satysfi-base.1.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-dejavu" {>= "2.37"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "base"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/nyuichi/satysfi-lib/archive/1.2.0.tar.gz"
+  checksum: [
+    "md5=898fa5db08ee8399fc1d1012eb9c6308"
+    "sha512=f205e1ad9cd8c780538bbc9b7350c6022ba5e09ff6637634d7ea78befc5f2c9bb9779a0c3b7f3d79f6d5f413540fce3442b2a63b909e72a397835bec246e0b5a"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.2.0`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0