### PR TITLE
2 packages from zeptometer/SATySFi-fonts-computer-modern at 0.7.0+satysfi0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
       satysfi-enumitem
       satysfi-fonts-asana-math
       satysfi-fonts-asana-math-doc
+      satysfi-fonts-computer-modern
+      satysfi-fonts-computer-modern-doc
       satysfi-fonts-dejavu
       satysfi-fonts-dejavu-doc
       satysfi-fonts-theano

--- a/packages/satysfi-fonts-computer-modern-doc/satysfi-fonts-computer-modern-doc.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-doc/satysfi-fonts-computer-modern-doc.0.7.0+satysfi0.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Donald Knuth's Computer Modern Fonts"
+description: """
+Document package for satysfi-fonts-computer-modern
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern.git"
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.0"}
+  "satysfi-fonts-computer-modern" {= "0.7.0+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-computer-modern-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-computer-modern-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-computer-modern/archive/0.7.0+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=7f8c11a39b6d0dab1b02c8139ce6e6aa"
+    "sha512=145e3d2980427a54b5812306e0bdfde9c79ffb7a9e30f361a99a770047a0f714b3f6328dcab15401f07a2e7a67469c26f7d985dc14fd504bada9e768bd467fc5"
+  ]
+}

--- a/packages/satysfi-fonts-computer-modern/satysfi-fonts-computer-modern.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern/satysfi-fonts-computer-modern.0.7.0+satysfi0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Donald Knuth's Computer Modern Fonts"
+description: """
+SATySFi font package for Donald Knuth's Computer Modern Fonts.
+
+This package installs fonts from https://www.checkmyworking.com/cm-web-fonts/.
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern.git"
+extra-source "computer-modern.zip" {
+  archive: "https://www.checkmyworking.com/cm-web-fonts/Computer%20Modern.zip"
+  checksum: [
+    "sha256=c240fff666a7d66de83a9f09ef045732c07291f2c83a07ae25ed888dc92f00f0"
+    "sha512=fddad701425d1d1e761f1998b9a168fb60dff5972a858e44ae107e9bfa1678f807e71055b93b0969d29a0d728233a5532edc02c0655bded3ac5bc69b580da0c4"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "computer-modern" "-o" "computer-modern.zip" "*.ttf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-computer-modern"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-computer-modern/archive/0.7.0+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=7f8c11a39b6d0dab1b02c8139ce6e6aa"
+    "sha512=145e3d2980427a54b5812306e0bdfde9c79ffb7a9e30f361a99a770047a0f714b3f6328dcab15401f07a2e7a67469c26f7d985dc14fd504bada9e768bd467fc5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-computer-modern.0.7.0+satysfi0.0.4`: SATySFi Font Package for Donald Knuth's Computer Modern Fonts
-`satysfi-fonts-computer-modern-doc.0.7.0+satysfi0.0.4`: Document of SATySFi Font Package for Donald Knuth's Computer Modern Fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-computer-modern
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-computer-modern.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-computer-modern/issues

---
:camel: Pull-request generated by opam-publish v2.0.2