### PR TITLE
2 packages from zeptometer/SATySFi-fonts-computer-modern-unicode at 0.7.0+satysfi0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
       satysfi-enumitem
       satysfi-fonts-asana-math
       satysfi-fonts-asana-math-doc
+      satysfi-fonts-computer-modern-unicode
+      satysfi-fonts-computer-modern-unicode-doc
       satysfi-fonts-dejavu
       satysfi-fonts-dejavu-doc
       satysfi-fonts-theano

--- a/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Computer Modern Unicode fonts"
+description: """
+Document package for satysfi-fonts-computer-modern-unicode
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode.git"
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.0"}
+  "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-computer-modern-unicode-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-computer-modern-unicode-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/archive/0.7.0+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=110f4fd4a8c0b9bdf2bd8ddf8c86d92c"
+    "sha512=94cf67729a380c1986b8b47a59fe8106d5dd997bb9d2f270274efe9e30774d2c9c143108ea4e0c31ac7d92ab835f9957697343c5cc833a9629c816fba46ae02f"
+  ]
+}

--- a/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Computer Modern Unicode fonts"
+description: """
+SATySFi font package for Computer Modern Unicode fonts.
+
+This package installs fonts from https://cm-unicode.sourceforge.io.
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode.git"
+extra-source "computer-modern-unicode.tar.xz" {
+  archive: "https://sourceforge.net/projects/cm-unicode/files/latest/download"
+  checksum: [
+    "sha256=2609c14450f42d0bcd40203900afcb1d693521a9b24a18c65e14b6b0585ff150"
+    "sha512=6340b7c6b220c8c887a4b77e77a01a43bedf13d08dd1d62570de70866d0bff908adf3fcb7907149ab2f5ab060650b39eaad3c01c1e8d028bbeb879b058190e70"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.3+dev2019.02.12" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["tar" "xf" "computer-modern-unicode.tar.xz"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-computer-modern-unicode"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/archive/0.7.0+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=110f4fd4a8c0b9bdf2bd8ddf8c86d92c"
+    "sha512=94cf67729a380c1986b8b47a59fe8106d5dd997bb9d2f270274efe9e30774d2c9c143108ea4e0c31ac7d92ab835f9957697343c5cc833a9629c816fba46ae02f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4`: SATySFi Font Package for Computer Modern Unicode fonts
-`satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4`: Document of SATySFi Font Package for Computer Modern Unicode fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/issues

---
:camel: Pull-request generated by opam-publish v2.0.2