### PR TITLE
Fix synopsis fields

### DIFF
--- a/packages/satysfi-make-html/satysfi-make-html.0.1.0/opam
+++ b/packages/satysfi-make-html/satysfi-make-html.0.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-make-html"
-synopsis: "outputting HTML file using SATySFi's text-mode."
+synopsis: "Outputting HTML file using SATySFi's text-mode"
 description: """outputting HTML file using SATySFi's text-mode."""
 
 maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"

--- a/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
+++ b/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-make-markdown"
-synopsis: "outputting Markdown file using SATySFi's text-mode."
+synopsis: "Outputting Markdown file using SATySFi's text-mode"
 description: """outputting Markdown file using SATySFi's text-mode."""
 
 maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"


### PR DESCRIPTION
This PR fixes synopsis fields which should start with a capital letter and not to have a period at the end.