### PR TITLE
Package satyrographos.0.0.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ env:
   # Stable version
   - OCAML_VERSION=4.06 EXTRA_DEPS="satysfi.0.0.4
     satysfi-dist
-    satyrographos=0.0.2.3
+    satyrographos=0.0.2.4
     $PACKAGES_FOR_STABLE"
   # Develop version
   - OCAML_VERSION=4.06 EXTRA_DEPS="satysfi.0.0.4+dev2020.02.22
     satysfi-dist
-    satyrographos=0.0.2.3
+    satyrographos=0.0.2.4
     $PACKAGES_FOR_STABLE"
 os:
   - linux

--- a/packages/satyrographos/satyrographos.0.0.2.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.4/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  (
+    "dune" {>= "1.11"} & "ocaml" {>= "4.07.0"}
+  | (* ppx_inline_test v0.11 requires dune 1 *)
+    "dune" {>= "1.11" & < "2" } & "ocaml" {< "4.07.0"}
+  )
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "re" {with-test}
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {< "v0.14"}
+  "ppx_jane"
+  "shexp"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.4.tar.gz"
+  checksum: [
+    "md5=0c0e450f7acba07bffb4277da3dd2f5f"
+    "sha512=1e69b8e072b57e247430f009761d1037e0fa44f5edbd42da0e668f45709e657f773979cfebcc10ca232dd0c1b20a3fb50b43b491db30663b7c908de1c868d884"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.4`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2