### PR TITLE
Package satysfi-base.1.2.1

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.2.1/opam
+++ b/packages/satysfi-base/satysfi-base.1.2.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
+  "satysfi-fonts-dejavu" {>= "2.37"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "base"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/nyuichi/satysfi-base/archive/1.2.1.tar.gz"
+  checksum: [
+    "md5=55c87283fc939b125c1817d26489cd6e"
+    "sha512=d2b3f0fa8bdec25311665bbc1c3c3202d88be95d7288addb5bb8adf6d0a6b84b38d885375f93286ef901a4b152434548906c7579f01078acd2e71c858abea336"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.2.1`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0