### PR TITLE
2 packages from zeptometer/SATySFi-fonts-noto-sans-cjk-jp at 2.001ver1+satysfi0.0.4

### DIFF
--- a/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001ver1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001ver1+satysfi0.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Noto Sans CJK JP fonts"
+description: """
+Document package for satysfi-fonts-noto-sans-cjk-jp
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.0"}
+  "satysfi-fonts-noto-sans-cjk-jp" {= "2.001ver1+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-noto-sans-cjk-jp-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-noto-sans-cjk-jp-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/archive/2.001ver1+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=d02769b9fc7811a80473093558c82359"
+    "sha512=63f4316fb0637629fbacda9bc99f6e07bd0d59143402ea7edc7fdb49b784431fb496e207b8dfa9831c3d565f013be246a3b113d4cae3d568b1b13adfcd8e604c"
+  ]
+}

--- a/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001ver1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001ver1+satysfi0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Noto Sans CJK JP fonts"
+description: """
+SATySFi font package for Noto Sans CJK JP fonts.
+
+This package installs fonts from https://www.google.com/get/noto/.
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp.git"
+extra-source "noto-sans-cjk-jp.zip" {
+  archive: "https://github.com/zeptometer/noto-cjk/releases/download/NotoSansV2.001/NotoSansCJKJp.zip"
+  checksum: [
+    "sha256=9bb52135d9e73279e083813d89e91466b1a3a50f7007e5062c23b89b7f776a70"
+    "sha512=cdc67d22fe2550d48ca7f962edb35607f84f781f508075634d1844ba26c829ee545241f596af1cda5699400ab0e7f96cf11e634ff2329dbfa160594f6c10d1c5"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "noto-sans-cjk-jp" "-o" "noto-sans-cjk-jp.zip" "*.otf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-noto-sans-cjk-jp"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/archive/2.001ver1+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=d02769b9fc7811a80473093558c82359"
+    "sha512=63f4316fb0637629fbacda9bc99f6e07bd0d59143402ea7edc7fdb49b784431fb496e207b8dfa9831c3d565f013be246a3b113d4cae3d568b1b13adfcd8e604c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-noto-sans-cjk-jp.2.001ver1+satysfi0.0.4`: SATySFi Font Package for Noto Sans CJK JP fonts
-`satysfi-fonts-noto-sans-cjk-jp-doc.2.001ver1+satysfi0.0.4`: Document of SATySFi Font Package for Noto Sans CJK JP fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2