### PR TITLE
2 packages from zeptometer/SATySFi-fonts-noto-serif-cjk-jp at 2.001ver1+satysfi0.0.4

### DIFF
--- a/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001ver1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001ver1+satysfi0.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Noto Serif CJK JP fonts"
+description: """
+Document package for satysfi-fonts-noto-serif-cjk-jp
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.0"}
+  "satysfi-fonts-noto-serif-cjk-jp" {= "2.001ver1+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "fonts-noto-serif-cjk-jp-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-noto-serif-cjk-jp-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/archive/2.001ver1+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=4d159896836e9649c0ffdf296d19fee3"
+    "sha512=41c57dbfd0df717f075ed341c50bc038f5a1805c2d51a67b0cbcff44966bb6f661d6944977ea122d2a8c3bc71c6909fca6ce5b3432ee8f10e9f004fec3f6a670"
+  ]
+}

--- a/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001ver1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001ver1+satysfi0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Noto Serif CJK JP fonts"
+description: """
+SATySFi font package for Noto Serif CJK JP fonts.
+
+This package installs fonts from https://www.google.com/get/noto/.
+"""
+maintainer: "Yuito Murase <yuito.murase@gmail.com>"
+authors: "Yuito Murase <yuito.murase@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp.git"
+extra-source "noto-serif-cjk-jp.zip" {
+  archive: "https://github.com/zeptometer/noto-cjk/releases/download/NotoSansV2.001/NotoSerifCJKJp.zip"
+  checksum: [
+    "sha256=90cf62ca126af39e92c70b569e3a4a3079d72f4e936c05a332513e6f866c5d5d"
+    "sha512=7647cecaef8c7a95d295e118d933dbc6d1e73526a0d7a18427b2a1f5a93bc14dc912573f333a37ae12ff92173a4740d60f9899be996e15fd8f8f5997d8363af1"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "noto-serif-cjk-jp" "-o" "noto-serif-cjk-jp.zip" "*.otf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-noto-serif-cjk-jp"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/archive/2.001ver1+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=4d159896836e9649c0ffdf296d19fee3"
+    "sha512=41c57dbfd0df717f075ed341c50bc038f5a1805c2d51a67b0cbcff44966bb6f661d6944977ea122d2a8c3bc71c6909fca6ce5b3432ee8f10e9f004fec3f6a670"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-noto-serif-cjk-jp.2.001ver1+satysfi0.0.4`: SATySFi Font Package for Noto Serif CJK JP fonts
-`satysfi-fonts-noto-serif-cjk-jp-doc.2.001ver1+satysfi0.0.4`: Document of SATySFi Font Package for Noto Serif CJK JP fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2