### PR TITLE
Temporarily remove satysfi-fonts-asana-math from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
       satysfi-class-slydifi
       satysfi-debug-show-value
       satysfi-enumitem
-      satysfi-fonts-asana-math
-      satysfi-fonts-asana-math-doc
       satysfi-fonts-computer-modern-unicode
       satysfi-fonts-computer-modern-unicode-doc
       satysfi-fonts-dejavu


### PR DESCRIPTION
Downloading files for satysfi-fonts-asana-math fails (https://travis-ci.com/github/na4zagin3/satyrographos-repo/jobs/314410628).

This PR temporarily removes the package from CI. It would be restored with #96.