### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.1

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.1/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Document: The yabaitech.tokyo SATySFi class file"
+description: """
+Document: The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: "Yuito Murase <yuito@acupof.coffee>"
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.1"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=eee27857a4d5f3e55d5c8bf1640ce273"
+    "sha512=804488cd3d2f13d9b888b97a2f05e0bc50819cc60bb9fd7d647bcb86cfe5b971201442da6adaffec0552987d025e596539def60e9654a912e1de74d8bde876f3"
+  ]
+}

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.1/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "The yabaitech.tokyo SATySFi class file"
+description: """
+The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: [
+    "gfngfn"
+    "Masaki Waga"
+    "Yuichi Nishiwaki <yuichi.nishiwaki@icloud.com>"
+    "Yuito Murase <yuito@acupof.coffee>"
+]
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.1" & < "2.0.0"}
+  "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-sans-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=eee27857a4d5f3e55d5c8bf1640ce273"
+    "sha512=804488cd3d2f13d9b888b97a2f05e0bc50819cc60bb9fd7d647bcb86cfe5b971201442da6adaffec0552987d025e596539def60e9654a912e1de74d8bde876f3"
+  ]
+}

--- a/satyrographos-repo-test-develop.opam
+++ b/satyrographos-repo-test-develop.opam
@@ -32,6 +32,7 @@ depends: [
   "satysfi-class-stjarticle"
   "satysfi-class-stjarticle-doc"
   "satysfi-class-slydifi"
+  "satysfi-class-yabaitech"
   "satysfi-debug-show-value"
   "satysfi-enumitem"
   "satysfi-fonts-asana-math"

--- a/satyrographos-repo-test-stable.opam
+++ b/satyrographos-repo-test-stable.opam
@@ -31,6 +31,7 @@ depends: [
   "satysfi-class-stjarticle"
   "satysfi-class-stjarticle-doc"
   "satysfi-class-slydifi"
+  "satysfi-class-yabaitech"
   "satysfi-debug-show-value"
   "satysfi-enumitem"
   "satysfi-fonts-asana-math"


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.1`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.1`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2