### PR TITLE
Package satyrographos.0.0.2.5

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.5/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2"}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "re" {with-test}
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.13" & < "v0.15"}
+  "ppx_jane"
+  "shexp"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.5.tar.gz"
+  checksum: [
+    "md5=a390b7cd0025b819f89507f328ef1cab"
+    "sha512=b928ba2f432c204c8808509a0ccc3b3858659d3a5e7fe4a40312b1c58cf3cd04eddc335b94e536c592074eca7a094b4897067069d3bf661ee888d3287a11e321"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.5`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2