### PR TITLE
Package satysfi-base.1.3.0

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.3.0/opam
+++ b/packages/satysfi-base/satysfi-base.1.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.5"}
+  "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
+  "satysfi-fonts-dejavu" {>= "2.37"}
+  "satysfi-zrbase" {>= "0.4.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "base"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/nyuichi/satysfi-base/archive/1.3.0.tar.gz"
+  checksum: [
+    "md5=a01fec04317611432422b713b9edad53"
+    "sha512=86be0df201b597ce58257b763728f573c20cc0581927054f5f7d3f903b4abfbb1cfc9b1bb243831ce6ff29d6b65c3bc607fa2175b42183add369e0b2bd7279aa"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.3.0`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.2