### PR TITLE
2 packages from monaqa/satysfi-easytable at 1.0.0

### DIFF
--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.0.0/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-easytable" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=b6f60771781aebfcf218bda56e0cd37c"
+    "sha512=b0fd07128a25285dd58b19b1b51e34d3e0c3d3c1f57f337b00a18e81f4630d20d0a717b9aad220d1872e742efb9e918c96195938a9fce34fa22510322aae027f"
+  ]
+}

--- a/packages/satysfi-easytable/satysfi-easytable.1.0.0/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=b6f60771781aebfcf218bda56e0cd37c"
+    "sha512=b0fd07128a25285dd58b19b1b51e34d3e0c3d3c1f57f337b00a18e81f4630d20d0a717b9aad220d1872e742efb9e918c96195938a9fce34fa22510322aae027f"
+  ]
+}

--- a/satyrographos-repo-test-develop.opam
+++ b/satyrographos-repo-test-develop.opam
@@ -36,6 +36,8 @@ depends: [
   "satysfi-class-yabaitech" {= "0.0.1"}
   "satysfi-class-yabaitech" {= "0.0.1"}
   "satysfi-debug-show-value" {= "0.1.1"}
+  "satysfi-easytable" {= "1.0.0"}
+  "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-enumitem" {= "2.0.0"}
   "satysfi-enumitem-doc" {= "2.0.0"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}

--- a/satyrographos-repo-test-stable-0-0-5.opam
+++ b/satyrographos-repo-test-stable-0-0-5.opam
@@ -36,6 +36,8 @@ depends: [
   "satysfi-class-yabaitech" {= "0.0.1"}
   "satysfi-class-yabaitech" {= "0.0.1"}
   "satysfi-debug-show-value" {= "0.1.1"}
+  "satysfi-easytable" {= "1.0.0"}
+  "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-enumitem" {= "2.0.0"}
   "satysfi-enumitem-doc" {= "2.0.0"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}


### PR DESCRIPTION
A SATySFi package to build simple tables

This pull-request concerns:
-`satysfi-easytable.1.0.0`
-`satysfi-easytable-doc.1.0.0`



---
* Homepage: https://github.com/monaqa/satysfi-easytable
* Source repo: git+https://github.com/monaqa/satysfi-easytable.git
* Bug tracker: https://github.com/monaqa/satysfi-easytable/issues

---
:camel: Pull-request generated by opam-publish v2.0.2