### PR TITLE
2 packages from uemurax/satysfi-ncsq at 0.0.1

### DIFF
--- a/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.0.0.1/opam
+++ b/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.0.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+This package provides documentation for the package.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & "< 0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & "< 0.0.6"}
+  "satysfi-ncsq" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=dd72b2bf2c53f0742810b64ab5683d79"
+    "sha512=481f98bac265d8a393e3d9d20b068d03aef5f575f4b6f0b9ee6ffd4f8290c5a713e7514d2481d9b320cdf5ed284458feacc92aaa63d5b24fb51ee4257f873163"
+  ]
+}

--- a/packages/satysfi-ncsq/satysfi-ncsq.0.0.1/opam
+++ b/packages/satysfi-ncsq/satysfi-ncsq.0.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-base" {>= "1.2.1"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=dd72b2bf2c53f0742810b64ab5683d79"
+    "sha512=481f98bac265d8a393e3d9d20b068d03aef5f575f4b6f0b9ee6ffd4f8290c5a713e7514d2481d9b320cdf5ed284458feacc92aaa63d5b24fb51ee4257f873163"
+  ]
+}


### PR DESCRIPTION
SATySFi package for drawing rectangular diagrams

This pull-request concerns:
-`satysfi-ncsq.0.0.1`
-`satysfi-ncsq-doc.0.0.1`



---
* Homepage: https://github.com/uemurax/satysfi-ncsq
* Source repo: git+https://github.com/uemurax/satysfi-ncsq.git
* Bug tracker: https://github.com/uemurax/satysfi-ncsq/issues

---
:camel: Pull-request generated by opam-publish v2.0.2