### PR TITLE
Change LICENCE of snapshot packages

### DIFF
--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -6,7 +6,7 @@ authors: [
 homepage: "https://github.com/na4zagin3/satyrographos-repo"
 dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
 bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
-license: "LGPL3+"
+license: "CC0"
 
 synopsis: "Snapshot of stable libraries in Satyrographos Repo"
 

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -6,7 +6,7 @@ authors: [
 homepage: "https://github.com/na4zagin3/satyrographos-repo"
 dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
 bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
-license: "LGPL3+"
+license: "CC0"
 
 synopsis: "Snapshot of stable libraries in Satyrographos Repo"
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -6,7 +6,7 @@ authors: [
 homepage: "https://github.com/na4zagin3/satyrographos-repo"
 dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
 bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
-license: "LGPL3+"
+license: "CC0"
 
 synopsis: "Snapshot of stable libraries in Satyrographos Repo"
 


### PR DESCRIPTION
Snapshot packages are unnecessarily licensed with LGPL3. This PR changes the license to CC0.