### PR TITLE
2 packages from uemurax/satysfi-ncsq at 0.1.0

### DIFF
--- a/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.0.1.0/opam
+++ b/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+This package provides documentation for the package.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & "< 0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & "< 0.0.6"}
+  "satysfi-ncsq" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=4dc2a618dd46b8f7daa398180e188797"
+    "sha512=fdcbe3b3aee8887289a2ef7248da9d89820b3cfc576f84f66096099c646c24e27168469d0da3faf48c8fe536a53fb43ab303b4b1c45539b889b170e540bcf1cb"
+  ]
+}

--- a/packages/satysfi-ncsq/satysfi-ncsq.0.1.0/opam
+++ b/packages/satysfi-ncsq/satysfi-ncsq.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-base" {>= "1.2.1"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=4dc2a618dd46b8f7daa398180e188797"
+    "sha512=fdcbe3b3aee8887289a2ef7248da9d89820b3cfc576f84f66096099c646c24e27168469d0da3faf48c8fe536a53fb43ab303b4b1c45539b889b170e540bcf1cb"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -25,6 +25,8 @@ depends: [
 
 # Package List
 
+  "satyrographos-snapshot-stable" {= "0.0.4+2020.07.20"}
+  "satyrographos-snapshot-stable" {= "0.0.5+2020.07.20"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi" {= "0.0.2"}
@@ -69,7 +71,9 @@ depends: [
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
   "satysfi-musikui" {= "0.1.0"}
   "satysfi-ncsq" {= "0.0.1"}
+  "satysfi-ncsq" {= "0.1.0"}
   "satysfi-ncsq-doc" {= "0.0.1"}
+  "satysfi-ncsq-doc" {= "0.1.0"}
   "satysfi-num-conversion" {= "0.1.1"}
   "satysfi-simple-itemize" {= "1.0.0"}
   "satysfi-siunitx" {= "0.1"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -25,6 +25,8 @@ depends: [
 
 # Package List
 
+  "satyrographos-snapshot-stable" {= "0.0.4+2020.07.20"}
+  "satyrographos-snapshot-stable" {= "0.0.5+2020.07.20"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi" {= "0.0.2"}
@@ -69,7 +71,9 @@ depends: [
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
   "satysfi-musikui" {= "0.1.0"}
   "satysfi-ncsq" {= "0.0.1"}
+  "satysfi-ncsq" {= "0.1.0"}
   "satysfi-ncsq-doc" {= "0.0.1"}
+  "satysfi-ncsq-doc" {= "0.1.0"}
   "satysfi-num-conversion" {= "0.1.1"}
   "satysfi-simple-itemize" {= "1.0.0"}
   "satysfi-siunitx" {= "0.1"}


### PR DESCRIPTION
SATySFi package for drawing rectangular diagrams

This pull-request concerns:
-`satysfi-ncsq.0.1.0`
-`satysfi-ncsq-doc.0.1.0`



---
* Homepage: https://github.com/uemurax/satysfi-ncsq
* Source repo: git+https://github.com/uemurax/satysfi-ncsq.git
* Bug tracker: https://github.com/uemurax/satysfi-ncsq/issues

---
:camel: Pull-request generated by opam-publish v2.0.2