### PR TITLE
Fix dependencies of snapshots

### DIFF
--- a/scripts/update-snapshot
+++ b/scripts/update-snapshot
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 changed_packages () {
-	git diff master --name-only | sed -e '/packages\/.*\/opam/!d' -e 's!packages/[^/]*/!!' -e 's!/opam$!!'
+	git diff origin/master... --name-only | sed \
+		-e '/packages\/.*\/opam/!d' \
+		-e 's!packages/[^/]*/!!' \
+		-e 's!/opam$!!' \
+		-e '/^satyrographos[-.]/d' \
+		-e '/^satysfi[.]/d'
 }
 
 filter_not_in () {

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -25,8 +25,6 @@ depends: [
 
 # Package List
 
-  "satyrographos-snapshot-stable" {= "0.0.4+2020.07.20"}
-  "satyrographos-snapshot-stable" {= "0.0.5+2020.07.20"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi" {= "0.0.2"}
@@ -70,9 +68,7 @@ depends: [
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
   "satysfi-musikui" {= "0.1.0"}
-  "satysfi-ncsq" {= "0.0.1"}
   "satysfi-ncsq" {= "0.1.0"}
-  "satysfi-ncsq-doc" {= "0.0.1"}
   "satysfi-ncsq-doc" {= "0.1.0"}
   "satysfi-num-conversion" {= "0.1.1"}
   "satysfi-simple-itemize" {= "1.0.0"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -25,8 +25,6 @@ depends: [
 
 # Package List
 
-  "satyrographos-snapshot-stable" {= "0.0.4+2020.07.20"}
-  "satyrographos-snapshot-stable" {= "0.0.5+2020.07.20"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi" {= "0.0.2"}
@@ -70,9 +68,7 @@ depends: [
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
   "satysfi-musikui" {= "0.1.0"}
-  "satysfi-ncsq" {= "0.0.1"}
   "satysfi-ncsq" {= "0.1.0"}
-  "satysfi-ncsq-doc" {= "0.0.1"}
   "satysfi-ncsq-doc" {= "0.1.0"}
   "satysfi-num-conversion" {= "0.1.1"}
   "satysfi-simple-itemize" {= "1.0.0"}


### PR DESCRIPTION
This also fixes update-snapshot script

- Calculate diff from the common ancester of origin/master and HEAD instead of diff from master.
- Exclude satyrographos and packages prefixed with satyrographos-

