### PR TITLE
Workaround OPAM fails in different error messages in Travis

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -33,8 +33,11 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 
             declare -a PACKAGES_AND_OPTIONS=('--strict' '--with-test' "$SATYSFI_PACKAGE" "$SNAPSHOT" "$PACKAGE")
 
-            if ! opam install --json=opam-output.json --dry-run "${PACKAGES_AND_OPTIONS[@]}"
+            if ! opam install --json=opam-output.json --dry-run --unlock-base "${PACKAGES_AND_OPTIONS[@]}"
             then
+                echo "Assuming dependency does not meet. Skipping"
+                continue
+
                 if jq -e '.conflicts["causes"] | index("No available version of satysfi satisfies the constraints")' opam-output.json
                 then
                     echo "Dependency does not meet. Skipping"


### PR DESCRIPTION
Workaround a problem where error messages in Travis is like

```
+ opam install --json=opam-output.json --dry-run --strict --with-test satysfi.0.0.4 snapshot-stable-0-0-4 satysfi-ncsq-doc.1.0.0

<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
[snapshot-stable-0-0-4.~dev] synchronised from file:///home/travis/build/na4zagin3/satyrographos-repo

[NOTE] Package satysfi is already installed (current version is 0.0.4).
The following dependencies couldn't be met:
  - satysfi-ncsq-doc → satysfi-easytable → satysfi >= 0.0.5 → ocaml >= 4.08.0
      base of this switch (use `--unlock-base' to force)

No solution found, exiting
```

```
+ opam install --json=opam-output.json --dry-run --strict --with-test satysfi.0.0.4 snapshot-stable-0-0-4 satysfi-ncsq.1.0.0

<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
[snapshot-stable-0-0-4.~dev] synchronised from file:///home/mrty/Documents/Development/satysfi/satyrographos-repo

The following dependencies couldn't be met:
  - satysfi-ncsq -> satysfi >= 0.0.5
Your request can't be satisfied:
  - No available version of satysfi satisfies the constraints

No solution found, exiting
```

rather than