### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.2

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.2/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Document: The yabaitech.tokyo SATySFi class file"
+description: """
+Document: The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: "Yuito Murase <yuito@acupof.coffee>"
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.2"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.2.tar.gz"
+  checksum: [
+    "md5=c2a7efa40b3a6641ca65ee7040750081"
+    "sha512=565837219790170d4be5036792b3ba6e6e72506a8567c71682fab40ded8c2cd1acefba3b387ff5f675aad87042956b9d29b97d156ec743dacc9491404d37a3fc"
+  ]
+}

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.2/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "The yabaitech.tokyo SATySFi class file"
+description: """
+The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: [
+    "gfngfn"
+    "Masaki Waga"
+    "Yuichi Nishiwaki <yuichi.nishiwaki@icloud.com>"
+    "Yuito Murase <yuito@acupof.coffee>"
+]
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.1" & < "2.0.0"}
+  "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-sans-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.2.tar.gz"
+  checksum: [
+    "md5=c2a7efa40b3a6641ca65ee7040750081"
+    "sha512=565837219790170d4be5036792b3ba6e6e72506a8567c71682fab40ded8c2cd1acefba3b387ff5f675aad87042956b9d29b97d156ec743dacc9491404d37a3fc"
+  ]
+}

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -33,7 +33,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.1.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech" {= "0.0.1"}
+  "satysfi-class-yabaitech-doc" {= "0.0.2"}
+  "satysfi-class-yabaitech" {= "0.0.2"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -35,7 +35,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.1.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech" {= "0.0.1"}
+  "satysfi-class-yabaitech-doc" {= "0.0.2"}
+  "satysfi-class-yabaitech" {= "0.0.2"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-easytable" {= "1.0.0"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.2`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.2`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2