### PR TITLE
Package satysfi-lipsum.0.1.0

### DIFF
--- a/packages/satysfi-lipsum/satysfi-lipsum.0.1.0/opam
+++ b/packages/satysfi-lipsum/satysfi-lipsum.0.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package of dummy text"
+description: """A SATySFi package of dummy text."""
+
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-lipsum"
+bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "lipsum"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-lipsum/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=4df9270bc8a879173c1d23004e3ce91c"
+    "sha512=9ef217e872e1276c1f6526bb785f6f3b376282bcdb1fb0c66ac5b11aa42ec28819c37240c70bfad453e3e1245e5228f382852b5b408f933ed0082c8eee8db8ca"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -64,6 +64,7 @@ depends: [
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}
   "satysfi-karnaugh" {= "0.0.1"}
+  "satysfi-lipsum" {= "0.1.0"}
   "satysfi-make-html" {= "0.1.0"}
   "satysfi-make-markdown" {= "0.1.0"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}


### PR DESCRIPTION
### `satysfi-lipsum.0.1.0`
A SATySFi package of dummy text
A SATySFi package of dummy text.



---
* Homepage: https://github.com/puripuri2100/SATySFi-lipsum
* Source repo: git+https://github.com/puripuri2100/SATySFi-lipsum.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-lipsum/issues

---
:camel: Pull-request generated by opam-publish v2.0.2