### PR TITLE
Package satysfi-lipsum.0.2.0

### DIFF
--- a/packages/satysfi-lipsum/satysfi-lipsum.0.2.0/opam
+++ b/packages/satysfi-lipsum/satysfi-lipsum.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package of dummy text"
+description: """A SATySFi package of dummy text."""
+
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-lipsum"
+bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
+
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "lipsum"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-lipsum/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=71ecc18a7ca586d1422452041b6d3d9f"
+    "sha512=dc1f606ced0c60fb7404d239da9847f989b1fe4d92a13930199f21e1d1bde26850781e22da208494aa0c9dbc503a39614e6c2e8ffc125d49bb2af0eeb875cf67"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -64,6 +64,7 @@ depends: [
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}
   "satysfi-karnaugh" {= "0.0.1"}
+  "satysfi-lipsum" {= "0.2.0"}
   "satysfi-make-html" {= "0.1.0"}
   "satysfi-make-markdown" {= "0.1.0"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -58,6 +58,7 @@ depends: [
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}
   "satysfi-karnaugh" {= "0.0.1"}
+  "satysfi-lipsum" {= "0.2.0"}
   "satysfi-make-html" {= "0.1.0"}
   "satysfi-make-markdown" {= "0.1.0"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -64,6 +64,7 @@ depends: [
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}
   "satysfi-karnaugh" {= "0.0.1"}
+  "satysfi-lipsum" {= "0.2.0"}
   "satysfi-make-html" {= "0.1.0"}
   "satysfi-make-markdown" {= "0.1.0"}
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}


### PR DESCRIPTION
### `satysfi-lipsum.0.2.0`
A SATySFi package of dummy text
A SATySFi package of dummy text.



---
* Homepage: https://github.com/puripuri2100/SATySFi-lipsum
* Source repo: git+https://github.com/puripuri2100/SATySFi-lipsum.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-lipsum/issues

---
:camel: Pull-request generated by opam-publish v2.0.2