### PR TITLE
2 packages from uemurax/satysfi-ncsq at 2.0.0

### DIFF
--- a/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.2.0.0/opam
+++ b/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.2.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+This package provides documentation for the package.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & "< 0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & "< 0.0.6"}
+  "satysfi-ncsq" {= "%{version}%"}
+  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-matrix" {>= "0.0.1" & "< 0.0.2"}
+  "satysfi-bibyfi" {>= "0.0.2" & "< 0.0.3"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=3112987789d89d6686f06f6481e36f2d"
+    "sha512=a58c5a97d82fda1c25951b27f9550096fb9f21b86edfb7f7d368d1bd64af6e50cca160a8512f155710a90a389f2f321a3026b543ace05ccb6015cf09033075b2"
+  ]
+}

--- a/packages/satysfi-ncsq/satysfi-ncsq.2.0.0/opam
+++ b/packages/satysfi-ncsq/satysfi-ncsq.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "SATySFi package for drawing rectangular diagrams"
+description: """
+Non-Commutative Squares (NCSq) is a SATySFi package for drawing rectangular diagrams.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-ncsq"
+bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-base" {>= "1.2.1"}
+  "satysfi-zrbase" {>= "0.4.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "ncsq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-ncsq/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=3112987789d89d6686f06f6481e36f2d"
+    "sha512=a58c5a97d82fda1c25951b27f9550096fb9f21b86edfb7f7d368d1bd64af6e50cca160a8512f155710a90a389f2f321a3026b543ace05ccb6015cf09033075b2"
+  ]
+}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -70,8 +70,8 @@ depends: [
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
   "satysfi-musikui" {= "0.1.0"}
-  "satysfi-ncsq-doc" {= "1.0.0"}
-  "satysfi-ncsq" {= "1.0.0"}
+  "satysfi-ncsq-doc" {= "2.0.0"}
+  "satysfi-ncsq" {= "2.0.0"}
   "satysfi-num-conversion" {= "0.1.1"}
   "satysfi-simple-itemize" {= "1.0.0"}
   "satysfi-siunitx" {= "0.1"}


### PR DESCRIPTION
SATySFi package for drawing rectangular diagrams

This pull-request concerns:
-`satysfi-ncsq.2.0.0`
-`satysfi-ncsq-doc.2.0.0`



---
* Homepage: https://github.com/uemurax/satysfi-ncsq
* Source repo: git+https://github.com/uemurax/satysfi-ncsq.git
* Bug tracker: https://github.com/uemurax/satysfi-ncsq/issues

---
:camel: Pull-request generated by opam-publish v2.0.2