### PR TITLE
Apply patch to squelch false positive warnings

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.5/files/allow-unannotated-ignores.patch
+++ b/packages/satyrographos/satyrographos.0.0.2.5/files/allow-unannotated-ignores.patch
@@ -1,0 +1,24 @@
+diff --git a/bin/dune b/bin/dune
+index d072c9b..2865a06 100644
+--- a/bin/dune
++++ b/bin/dune
+@@ -1,7 +1,7 @@
+ (executable
+  (name main)
+  (public_name satyrographos)
+- (preprocess (pps ppx_deriving.std ppx_jane))
++ (preprocess (pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
+  (libraries core satyrographos_command shexp.process uri)
+  (modules setup renameOption compatibility commandInstall commandLibrary commandOpam commandPin commandSatysfi commandStatus main)
+  )
+diff --git a/src/command/dune b/src/command/dune
+index ab63cc7..4d2f93b 100644
+--- a/src/command/dune
++++ b/src/command/dune
+@@ -1,5 +1,5 @@
+ (library
+  (name satyrographos_command)
+  (inline_tests)
+- (preprocess (staged_pps ppx_deriving.std ppx_jane))
++ (preprocess (staged_pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
+  (libraries core fileutils satyrographos satyrographos_autogen shexp.process))

--- a/packages/satyrographos/satyrographos.0.0.2.5/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.5/opam
@@ -49,3 +49,5 @@ url {
     "sha512=b928ba2f432c204c8808509a0ccc3b3858659d3a5e7fe4a40312b1c58cf3cd04eddc335b94e536c592074eca7a094b4897067069d3bf661ee888d3287a11e321"
   ]
 }
+extra-files: ["allow-unannotated-ignores.patch" "sha256=af6ee00873733a0f5dcda0e47702c8aa7c8b40f40c6194575a8a8796a3a54ab0"]
+patches: ["allow-unannotated-ignores.patch"]


### PR DESCRIPTION
[ppx_js_style](https://github.com/janestreet/ppx_js_style) started to
report false positive warnings.  This PR keep it from reporting
them.