### PR TITLE
Package satyrographos.0.0.2.6

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.6/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.6/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2"}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving"
+  "opam-format" {>= "2.0" & < "2.1"}
+  "re" {with-test}
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.13" & < "v0.15"}
+  "ppx_jane"
+  "shexp"
+]
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.2.6.tar.gz"
+  checksum: [
+    "md5=35cf2d9e084c58a83673fc2dd802801b"
+    "sha512=10aa7ac33429a31a9d802bb7b6cb301a0a00d787a735083cb67abd8a9871c864a4d38b8d04da30ccbd0cd302a2c4c72d4c50b5070386af651dc07721d2244b23"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "satysfi" {= "0.0.5"}
   "satysfi-dist"
-  "satyrographos" {= "0.0.2.5"}
+  "satyrographos" {= "0.0.2.6"}
 
 
 # Package List

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "satysfi" {= "0.0.5"}
   "satysfi-dist"
-  "satyrographos" {= "0.0.2.5"}
+  "satyrographos" {= "0.0.2.6"}
 
 
 # Package List


### PR DESCRIPTION
### `satyrographos.0.0.2.6`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.0.2