### PR TITLE
Add satysfi dev version satysfi.0.0.5+dev2020.09.05

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/files/fix-install-libs.patch
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/files/fix-install-libs.patch
@@ -1,0 +1,12 @@
+diff --git a/install-libs.sh b/install-libs.sh
+index 49fdd16..9c7dd11 100755
+--- a/install-libs.sh
++++ b/install-libs.sh
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-LIBDIR=/usr/local/share/satysfi
++LIBDIR=${1:-/usr/local/share/satysfi}
+ 
+ install -d ${LIBDIR}
+ install -d ${LIBDIR}/dist

--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "gfngfn"
+]
+extra-source "temp/lm2.004otf.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  checksum: [
+    "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
+    "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
+  ]
+}
+extra-source "temp/latinmodern-math-1959.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  checksum: [
+    "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
+    "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"
+  ]
+}
+extra-source "temp/junicode-1.002.zip" {
+  archive: "http://downloads.sourceforge.net/project/junicode/junicode/junicode-1.002/junicode-1.002.zip"
+  checksum: [
+    "sha256=c199d96c8424be60fcab8d00d2eee39ea8ae632cfd5e710cbbd70626d6a729e7"
+    "sha512=1738802f70b0029567be608ed36481864f8f7f029fd1c45d73fa25d092d49c978c51df1c01147b7b176e9b0409d7f15d5713a6daf1b1b269636bc6324b2c6f37"
+  ]
+}
+extra-source "temp/IPAexfont00401.zip" {
+  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
+  ]
+  checksum: [
+    "sha256=bcf8374ab3f9672c421120430dd19a51c99f5265cf06fc340d9a661ddfd7974b"
+    "sha512=fe639ded0a25eed66df8cc1e9d5e965b501574a25fab542a749b3cb8464690448e44343ff5845aecd3224ec481c4089ee56e64880cbbc9211a260b22d4cc68cd"
+  ]
+}
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["./download-fonts.sh"]
+]
+install: [
+  ["./install-libs.sh" "%{share}%/satysfi"]
+]
+remove: [
+  ["rm" "-rf" "%{share}%/satysfi/dist"]
+]
+depends: [
+  "satysfi" {= "%{version}%" }
+]
+synopsis: "Standard library of SATySFi"
+description: """
+Provides the standard library of SATySFi"""
+extra-files: ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
+patches: ["fix-install-libs.patch"]
+url {
+  git: "git+https://github.com/gfngfn/SATySFi.git#4e8ea2147f66b8c26a494067b3011e480be6526e"
+}

--- a/packages/satysfi/satysfi.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi/satysfi.0.0.5+dev2020.09.05/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "gfngfn"
+authors: [
+  "gfngfn"
+]
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["mkdir" "-p" "temp"]
+  [make "-f" "Makefile" "PREFIX=%{prefix}%"]
+]
+install: [
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%"]
+]
+# Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "batteries"
+  "camlimages" {>= "5.0.1"}
+  "camlpdf" {= "2.3.1+satysfi"}
+  "core_kernel" {>= "v0.13"}
+  "cppo" {build & >= "1.6.4" & < "1.7.0"}
+  "depext"
+  "dune" {build}
+  "menhir"
+  "ocamlfind" {build}
+  "otfm" {= "0.3.7+satysfi"}
+  "ppx_deriving"
+  "re" {build}
+  "uutf"
+  "yojson-with-position" {= "1.4.2+satysfi"}
+  "omd"
+]
+synopsis: "A statically-typed, functional typesetting system"
+description: """
+SATySFi is a typesetting system with a static type system. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has ML-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""
+url {
+  git: "git+https://github.com/gfngfn/SATySFi.git#4e8ea2147f66b8c26a494067b3011e480be6526e"
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -13,7 +13,7 @@ synopsis: "Snapshot of stable libraries in Satyrographos Repo"
 depends: [
   "dune" {build}
   "ocaml" {>= "4.10.0"}
-  "satysfi" {= "0.0.5"}
+  "satysfi" {= "0.0.5+dev2020.09.05"}
   "satysfi-dist"
   "satyrographos" {= "0.0.2.6"}
 


### PR DESCRIPTION
This PR adds a new development version of SATySFI with version satysfi.0.0.5+dev2020.09.05.

Differences: https://github.com/gfngfn/SATySFi/compare/v0.0.5...4e8ea2147f66b8c26a494067b3011e480be6526e#diff-4ac32a78649ca5bdd8e0ba38b7006a1e