### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.3

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.3/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Document: The yabaitech.tokyo SATySFi class file"
+description: """
+Document: The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: "Yuito Murase <yuito@acupof.coffee>"
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.3"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=a92680cc026ed7161d04db4678d326d8"
+    "sha512=1b71cf7a32e3376cc1de34f8c87560dc13410a77befc6bff66ea4ccbc61b4d1c4f43db1c46853bd44747458e1c56d49cbca48386780009909b265737aec62da3"
+  ]
+}

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.3/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "The yabaitech.tokyo SATySFi class file"
+description: """
+The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: [
+    "gfngfn"
+    "Masaki Waga"
+    "Yuichi Nishiwaki <yuichi.nishiwaki@icloud.com>"
+    "Yuito Murase <yuito@acupof.coffee>"
+]
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.1" & < "2.0.0"}
+  "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-sans-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "class-yabaitech"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=a92680cc026ed7161d04db4678d326d8"
+    "sha512=1b71cf7a32e3376cc1de34f8c87560dc13410a77befc6bff66ea4ccbc61b4d1c4f43db1c46853bd44747458e1c56d49cbca48386780009909b265737aec62da3"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -30,8 +30,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.1.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech-doc" {= "0.0.2"}
-  "satysfi-class-yabaitech" {= "0.0.2"}
+  "satysfi-class-yabaitech-doc" {= "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.3"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-easytable" {= "1.0.0"}

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -28,8 +28,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.1.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech-doc" {= "0.0.2"}
-  "satysfi-class-yabaitech" {= "0.0.2"}
+  "satysfi-class-yabaitech-doc" {= "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.3"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -30,8 +30,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.1.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech-doc" {= "0.0.2"}
-  "satysfi-class-yabaitech" {= "0.0.2"}
+  "satysfi-class-yabaitech-doc" {= "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.3"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-easytable" {= "1.0.0"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.3`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.3`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2