### PR TITLE
2 packages from uemurax/satysfi-arrows at 0.1.0

### DIFF
--- a/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
+++ b/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A SATySFi arrows library"
+description: """
+A SATySFi library for drawing arrows.
+This package provides documentation for the package.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-arrows"
+bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-arrows" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "arrows-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"
+  ]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "arrows-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-arrows/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=b02342fb385e101d4bf785f289740261"
+    "sha512=aee5432e363032e8516a9062af08403f106d6fcf8640549d5967c58b1db6f9783455949162fed84b5709600eaf6bac6a896c657e4421ddd3e8333b53c93ce5c1"
+  ]
+}

--- a/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
+++ b/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/uemurax/satysfi-arrows"
 bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satysfi" {>= "0.0.5+dev2020.09.05" & < "0.0.6"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
   "satysfi-arrows" {= "%{version}%"}

--- a/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
+++ b/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A SATySFi arrows library"
+description: """
+A SATySFi library for drawing arrows.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Taichi Uemura <t.uemura00@gmail.com>"
+authors: "Taichi Uemura <t.uemura00@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/uemurax/satysfi-arrows"
+bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
+dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-base" {>= "1.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "arrows"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/uemurax/satysfi-arrows/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=b02342fb385e101d4bf785f289740261"
+    "sha512=aee5432e363032e8516a9062af08403f106d6fcf8640549d5967c58b1db6f9783455949162fed84b5709600eaf6bac6a896c657e4421ddd3e8333b53c93ce5c1"
+  ]
+}

--- a/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
+++ b/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/uemurax/satysfi-arrows"
 bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satysfi" {>= "0.0.5+dev2020.09.05" & < "0.0.6"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist" {>= "0.0.5" & < "0.0.6"}
   "satysfi-base" {>= "1.3"}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -20,6 +20,8 @@ depends: [
 
 # Package List
 
+  "satysfi-arrows-doc" {= "0.1.0"}
+  "satysfi-arrows" {= "0.1.0"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi-doc" {= "0.0.2"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -20,6 +20,8 @@ depends: [
 
 # Package List
 
+  "satysfi-arrows-doc" {= "0.1.0"}
+  "satysfi-arrows" {= "0.1.0"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi-doc" {= "0.0.2"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -20,8 +20,6 @@ depends: [
 
 # Package List
 
-  "satysfi-arrows-doc" {= "0.1.0"}
-  "satysfi-arrows" {= "0.1.0"}
   "satysfi-assert-eq" {= "0.1.1"}
   "satysfi-base" {= "1.3.0"}
   "satysfi-bibyfi-doc" {= "0.0.2"}


### PR DESCRIPTION
A SATySFi arrows library

This pull-request concerns:
-`satysfi-arrows.0.1.0`
-`satysfi-arrows-doc.0.1.0`



---
* Homepage: https://github.com/uemurax/satysfi-arrows
* Source repo: git+https://github.com/uemurax/satysfi-arrows.git
* Bug tracker: https://github.com/uemurax/satysfi-arrows/issues

---
:camel: Pull-request generated by opam-publish v2.0.2