### PR TITLE
2 packages from na4zagin3/SATySFi-fonts-junicode at 1.0002+satysfi0.0.5

### DIFF
--- a/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Junicode"
+description: """
+Document of SATySFi Font Package for Junicode
+
+This package installs fonts from https://junicode.sourceforge.io/
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-junicode"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-junicode/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-junicode.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-fonts-junicode" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-junicode-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-junicode-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-junicode/archive/v1.0002+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=ad786bf94037110d112c05f224080410"
+    "sha512=f9011e09b45edea623fe59db3df607530308c29e253e5b2ab34f3b76cc71759f1cca426a5e3de0b0a2a9060a773784d2c92b37e69233d2095e6c2a40440f8780"
+  ]
+}

--- a/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Junicode"
+description: """
+SATySFi Font Package for Junicode
+
+This package installs fonts from https://junicode.sourceforge.io/
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-junicode"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-junicode/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-junicode.git"
+extra-source "junicode-1.002.zip" {
+  archive: "http://downloads.sourceforge.net/project/junicode/junicode/junicode-1.002/junicode-1.002.zip"
+  checksum: [
+    "sha256=c199d96c8424be60fcab8d00d2eee39ea8ae632cfd5e710cbbd70626d6a729e7"
+    "sha512=1738802f70b0029567be608ed36481864f8f7f029fd1c45d73fa25d092d49c978c51df1c01147b7b176e9b0409d7f15d5713a6daf1b1b269636bc6324b2c6f37"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-o" "junicode-1.002.zip" "-d" "junicode"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-junicode"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-junicode/archive/v1.0002+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=ad786bf94037110d112c05f224080410"
+    "sha512=f9011e09b45edea623fe59db3df607530308c29e253e5b2ab34f3b76cc71759f1cca426a5e3de0b0a2a9060a773784d2c92b37e69233d2095e6c2a40440f8780"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -46,6 +46,8 @@ depends: [
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+  "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+  "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
   "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
   "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
   "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -44,6 +44,8 @@ depends: [
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+  "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+  "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
   "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
   "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
   "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-junicode.1.0002+satysfi0.0.5`: SATySFi Font Package for Junicode
-`satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5`: Document of SATySFi Font Package for Junicode



---
* Homepage: https://github.com/na4zagin3/SATySFi-fonts-junicode
* Source repo: git+https://github.com/na4zagin3/SATySFi-fonts-junicode.git
* Bug tracker: https://github.com/na4zagin3/SATySFi-fonts-junicode/issues

---
:camel: Pull-request generated by opam-publish v2.0.2