### PR TITLE
2 packages from na4zagin3/satysfi-fss at 0.0.1

### DIFF
--- a/packages/satysfi-fss-doc/satysfi-fss-doc.0.0.1/opam
+++ b/packages/satysfi-fss-doc/satysfi-fss-doc.0.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document: Font selection scheme"
+description: """
+Document: Font selection scheme for SATySFi
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "LGPL-3.0-or-later" # Choose what you want
+homepage: "https://github.com/na4zagin3/satysfi-fss"
+dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-fss" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fss-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fss-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/na4zagin3/satysfi-fss/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=55916bc44251fe420a82d59cf9fdf01a"
+    "sha512=e30dd5da75f02b7227ae6791a4ce06317ab245a4e760f34bfa67acbd4db3b518a2c3108347152d266784f42500cd94d7ab1efabe7732e168015396df9ee43098"
+  ]
+}

--- a/packages/satysfi-fss/satysfi-fss.0.0.1/opam
+++ b/packages/satysfi-fss/satysfi-fss.0.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Font selection scheme"
+description: """
+Document: Font selection scheme for SATySFi
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/na4zagin3/satysfi-fss"
+dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-fonts-junicode" {>= "1" & < "2"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fss"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/na4zagin3/satysfi-fss/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=55916bc44251fe420a82d59cf9fdf01a"
+    "sha512=e30dd5da75f02b7227ae6791a4ce06317ab245a4e760f34bfa67acbd4db3b518a2c3108347152d266784f42500cd94d7ab1efabe7732e168015396df9ee43098"
+  ]
+}

--- a/packages/satysfi-fss/satysfi-fss.0.0.1/opam
+++ b/packages/satysfi-fss/satysfi-fss.0.0.1/opam
@@ -13,6 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.6"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 
+  "satysfi-base" {>= "1.3.0" & < "2"}
   "satysfi-fonts-junicode" {>= "1" & < "2"}
 ]
 install: [

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -60,6 +60,8 @@ depends: [
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
   "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
   "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+  "satysfi-fss-doc" {= "0.0.1"}
+  "satysfi-fss" {= "0.0.1"}
   "satysfi-grcnum-doc" {= "0.2"}
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -58,6 +58,8 @@ depends: [
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
   "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
   "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+  "satysfi-fss-doc" {= "0.0.1"}
+  "satysfi-fss" {= "0.0.1"}
   "satysfi-grcnum-doc" {= "0.2"}
   "satysfi-grcnum" {= "0.2"}
   "satysfi-karnaugh-doc" {= "0.0.1"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fss.0.0.1`: Font selection scheme
-`satysfi-fss-doc.0.0.1`: Document: Font selection scheme



---
* Homepage: https://github.com/na4zagin3/satysfi-fss
* Source repo: git+https://github.com/na4zagin3/satysfi-fss.git
* Bug tracker: https://github.com/na4zagin3/satysfi-fss/issues

---
:camel: Pull-request generated by opam-publish v2.0.2