### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.4

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.4/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.4/opam
@@ -30,9 +30,9 @@ install: [
 ]
 url {
   src:
-    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.4.tar.gz"
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.5.tar.gz"
   checksum: [
-    "md5=2bcb6096d20a0b0e40785d3b76c70e99"
-    "sha512=e52216d111c91585a40954303047da2314d664a0d797f22ef008c80533aabe1d394a42d006c881e02c09246115f2666237c60b2fa24ab69840957b0b54e3cca9"
+    "md5=44ec53ec990a18632b823961bc305d96"
+    "sha512=c95cef998d4990a733ff47659e65b3703de20fe30d7b1ef223db5c103f42aff73b75ed31e55204101e7b37340b665417926ec89a22361648ff1f335c41118877"
   ]
 }

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.4/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.4/opam
@@ -34,9 +34,9 @@ install: [
 ]
 url {
   src:
-    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.4.tar.gz"
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.5.tar.gz"
   checksum: [
-    "md5=2bcb6096d20a0b0e40785d3b76c70e99"
-    "sha512=e52216d111c91585a40954303047da2314d664a0d797f22ef008c80533aabe1d394a42d006c881e02c09246115f2666237c60b2fa24ab69840957b0b54e3cca9"
+    "md5=44ec53ec990a18632b823961bc305d96"
+    "sha512=c95cef998d4990a733ff47659e65b3703de20fe30d7b1ef223db5c103f42aff73b75ed31e55204101e7b37340b665417926ec89a22361648ff1f335c41118877"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.4`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.4`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2