### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.5

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.5/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document: The yabaitech.tokyo SATySFi class file"
+description: """
+Document: The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: "Yuito Murase <yuito@acupof.coffee>"
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.5"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "class-yabaitech-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-yabaitech-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.5.tar.gz"
+  checksum: [
+    "md5=7647e7ae1f190f8f7a57cdd5fefdc7db"
+    "sha512=bcd3405158140f07d9b3c27f8beb434c0540bc2eceddd8b4cc8c51d17d297f2b49a0f1c56a194ff34960fb3dc498103542d0804e5cf02c17d6788b408323a83e"
+  ]
+}

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.5/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "The yabaitech.tokyo SATySFi class file"
+description: """
+The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: [
+    "gfngfn"
+    "Masaki Waga"
+    "Yuichi Nishiwaki <yuichi.nishiwaki@icloud.com>"
+    "Yuito Murase <yuito@acupof.coffee>"
+]
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.1" & < "2.0.0"}
+  "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-sans-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-yabaitech"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.5.tar.gz"
+  checksum: [
+    "md5=7647e7ae1f190f8f7a57cdd5fefdc7db"
+    "sha512=bcd3405158140f07d9b3c27f8beb434c0540bc2eceddd8b4cc8c51d17d297f2b49a0f1c56a194ff34960fb3dc498103542d0804e5cf02c17d6788b408323a83e"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -33,8 +33,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.2.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech-doc" {= "0.0.4"}
-  "satysfi-class-yabaitech" {= "0.0.4"}
+  "satysfi-class-yabaitech-doc" {= "0.0.5"}
+  "satysfi-class-yabaitech" {= "0.0.5"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-easytable" {= "1.0.0"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -31,8 +31,8 @@ depends: [
   "satysfi-class-slydifi" {= "0.2.0"}
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
   "satysfi-class-stjarticle" {= "1.3.2"}
-  "satysfi-class-yabaitech-doc" {= "0.0.4"}
-  "satysfi-class-yabaitech" {= "0.0.4"}
+  "satysfi-class-yabaitech-doc" {= "0.0.5"}
+  "satysfi-class-yabaitech" {= "0.0.5"}
   "satysfi-debug-show-value" {= "0.1.1"}
   "satysfi-easytable-doc" {= "1.0.0"}
   "satysfi-easytable" {= "1.0.0"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.5`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.5`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2