### PR TITLE
2 packages from na4zagin3/SATySFi-fonts-cormorant at 3.601+satysfi0.0.5

### DIFF
--- a/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Document: SATySFi Font Package for Cormorant"
+description: """
+Document: SATySFi Font Package for Cormorant
+
+This package installs fonts from https://github.com/CatharsisFonts/Cormorant
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-cormorant"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-cormorant/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-cormorant.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-fonts-cormorant" {= "%{version}%"}
+
+  "satysfi-lipsum"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-cormorant-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-cormorant-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-cormorant/archive/v3.601+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=342ddad1a03a450817fec942b9c9312c"
+    "sha512=d3707046a1bf457ba9205cef440ee240c79fccd90ce1c8bb9bee6d016f932026321a8d1d189973cd5ca769815c641003f700f3f390f7631c885b7b3d95103734"
+  ]
+}

--- a/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Cormorant"
+description: """
+SATySFi Font Package for Cormorant
+
+This package installs fonts from https://github.com/CatharsisFonts/Cormorant
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-cormorant"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-cormorant/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-cormorant.git"
+extra-source "Cormorant_Install_v3.601.zip" {
+  archive: "https://github.com/CatharsisFonts/Cormorant/releases/download/v3.601/Cormorant_Install_v3.601.zip"
+  checksum: [
+    "sha256=59997266f48655f7365c0de16d2c4ea6e92a7d8f549fd97c95f1cbe307901e1e"
+    "sha512=43f246fe9d74261fc9a2bcef96eb389cc0e8a21eeaa946eb42f3e9f2958fb864bef5357522728a7ef222fc5db0ddaae61be7678263a0d116cd558fe4340dc170"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-o" "Cormorant_Install_v3.601.zip" "-d" "cormorant"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-cormorant"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-cormorant/archive/v3.601+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=342ddad1a03a450817fec942b9c9312c"
+    "sha512=d3707046a1bf457ba9205cef440ee240c79fccd90ce1c8bb9bee6d016f932026321a8d1d189973cd5ca769815c641003f700f3f390f7631c885b7b3d95103734"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -44,6 +44,8 @@ depends: [
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+  "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+  "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -42,6 +42,8 @@ depends: [
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+  "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+  "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
   "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-cormorant.3.601+satysfi0.0.5`: SATySFi Font Package for Cormorant
-`satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5`: Document: SATySFi Font Package for Cormorant



---
* Homepage: https://github.com/na4zagin3/SATySFi-fonts-cormorant
* Source repo: git+https://github.com/na4zagin3/SATySFi-fonts-cormorant.git
* Bug tracker: https://github.com/na4zagin3/SATySFi-fonts-cormorant/issues

---
:camel: Pull-request generated by opam-publish v2.0.2