### PR TITLE
Add a line break after each package in snapshots 

### DIFF
--- a/scripts/update-snapshot
+++ b/scripts/update-snapshot
@@ -38,7 +38,7 @@ package_list_from_opam () {
 }
 
 package_list_to_opam () {
-	sed -e 's/^\([^.]*\)\.\(.*\)$/  "\1" {= "\2"}/'
+	sed -e 's/^\([^.]*\)\.\(.*\)$/  "\1" {= "\2"}\n/'
 }
 
 replace_package_list_in_opam () {

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -21,65 +21,126 @@ depends: [
 # Package List
 
   "satysfi-arrows-doc" {= "0.1.0"}
+
   "satysfi-arrows" {= "0.1.0"}
+
   "satysfi-assert-eq" {= "0.1.1"}
+
   "satysfi-base" {= "1.3.0"}
+
   "satysfi-bibyfi-doc" {= "0.0.2"}
+
   "satysfi-bibyfi" {= "0.0.2"}
+
   "satysfi-cancel" {= "0.0.0"}
+
   "satysfi-class-exdesign-doc" {= "0.2"}
+
   "satysfi-class-exdesign" {= "0.2"}
+
   "satysfi-class-slydifi-doc" {= "0.2.0"}
+
   "satysfi-class-slydifi" {= "0.2.0"}
+
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
   "satysfi-class-stjarticle" {= "1.3.2"}
+
   "satysfi-class-yabaitech-doc" {= "0.0.5"}
+
   "satysfi-class-yabaitech" {= "0.0.5"}
+
   "satysfi-debug-show-value" {= "0.1.1"}
+
   "satysfi-easytable-doc" {= "1.0.0"}
+
   "satysfi-easytable" {= "1.0.0"}
+
   "satysfi-enumitem-doc" {= "2.0.0"}
+
   "satysfi-enumitem" {= "2.0.0"}
+
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+
   "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
+
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+
   "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
+
   "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-fss-doc" {= "0.0.1"}
+
   "satysfi-fss" {= "0.0.1"}
+
   "satysfi-grcnum-doc" {= "0.2"}
+
   "satysfi-grcnum" {= "0.2"}
+
   "satysfi-karnaugh-doc" {= "0.0.1"}
+
   "satysfi-karnaugh" {= "0.0.1"}
+
   "satysfi-lipsum" {= "0.2.0"}
+
   "satysfi-make-html" {= "0.1.0"}
+
   "satysfi-make-markdown" {= "0.1.0"}
+
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-musikui" {= "0.1.0"}
+
   "satysfi-ncsq-doc" {= "2.1.0"}
+
   "satysfi-ncsq" {= "2.1.0"}
+
   "satysfi-num-conversion" {= "0.1.1"}
+
   "satysfi-simple-itemize" {= "1.0.0"}
+
   "satysfi-siunitx" {= "0.1"}
+
   "satysfi-uline" {= "0.2.0"}
+
   "satysfi-zrbase" {= "0.4.0"}
+
 # Package List End
 ]

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -21,47 +21,90 @@ depends: [
 # Package List
 
   "satysfi-assert-eq" {= "0.1.1"}
+
   "satysfi-base" {= "1.3.0"}
+
   "satysfi-cancel" {= "0.0.0"}
+
   "satysfi-class-exdesign-doc" {= "0.2"}
+
   "satysfi-class-exdesign" {= "0.2"}
+
   "satysfi-class-slydifi" {= "0.1.0"}
+
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
   "satysfi-class-stjarticle" {= "1.3.2"}
+
   "satysfi-class-yabaitech-doc" {= "0.0.3"}
+
   "satysfi-class-yabaitech" {= "0.0.3"}
+
   "satysfi-debug-show-value" {= "0.1.1"}
+
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-grcnum-doc" {= "0.2"}
+
   "satysfi-grcnum" {= "0.2"}
+
   "satysfi-karnaugh-doc" {= "0.0.1"}
+
   "satysfi-karnaugh" {= "0.0.1"}
+
   "satysfi-lipsum" {= "0.2.0"}
+
   "satysfi-make-html" {= "0.1.0"}
+
   "satysfi-make-markdown" {= "0.1.0"}
+
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-musikui" {= "0.1.0"}
+
   "satysfi-simple-itemize" {= "1.0.0"}
+
   "satysfi-siunitx" {= "0.1"}
+
   "satysfi-uline" {= "0.2.0"}
+
   "satysfi-zrbase" {= "0.4.0"}
+
 # Package List End
 ]

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -21,63 +21,122 @@ depends: [
 # Package List
 
   "satysfi-assert-eq" {= "0.1.1"}
+
   "satysfi-base" {= "1.3.0"}
+
   "satysfi-bibyfi-doc" {= "0.0.2"}
+
   "satysfi-bibyfi" {= "0.0.2"}
+
   "satysfi-cancel" {= "0.0.0"}
+
   "satysfi-class-exdesign-doc" {= "0.2"}
+
   "satysfi-class-exdesign" {= "0.2"}
+
   "satysfi-class-slydifi-doc" {= "0.2.0"}
+
   "satysfi-class-slydifi" {= "0.2.0"}
+
   "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
   "satysfi-class-stjarticle" {= "1.3.2"}
+
   "satysfi-class-yabaitech-doc" {= "0.0.5"}
+
   "satysfi-class-yabaitech" {= "0.0.5"}
+
   "satysfi-debug-show-value" {= "0.1.1"}
+
   "satysfi-easytable-doc" {= "1.0.0"}
+
   "satysfi-easytable" {= "1.0.0"}
+
   "satysfi-enumitem-doc" {= "2.0.0"}
+
   "satysfi-enumitem" {= "2.0.0"}
+
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
   "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+
   "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
+
   "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
   "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+
   "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
+
   "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
   "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
   "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
   "satysfi-fss-doc" {= "0.0.1"}
+
   "satysfi-fss" {= "0.0.1"}
+
   "satysfi-grcnum-doc" {= "0.2"}
+
   "satysfi-grcnum" {= "0.2"}
+
   "satysfi-karnaugh-doc" {= "0.0.1"}
+
   "satysfi-karnaugh" {= "0.0.1"}
+
   "satysfi-lipsum" {= "0.2.0"}
+
   "satysfi-make-html" {= "0.1.0"}
+
   "satysfi-make-markdown" {= "0.1.0"}
+
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
   "satysfi-musikui" {= "0.1.0"}
+
   "satysfi-ncsq-doc" {= "2.0.0"}
+
   "satysfi-ncsq" {= "2.0.0"}
+
   "satysfi-num-conversion" {= "0.1.1"}
+
   "satysfi-simple-itemize" {= "1.0.0"}
+
   "satysfi-siunitx" {= "0.1"}
+
   "satysfi-uline" {= "0.2.0"}
+
   "satysfi-zrbase" {= "0.4.0"}
+
 # Package List End
 ]


### PR DESCRIPTION
This PR inserts a line break after every package version constraint in the snapshots to reduce possibility of merge conflicts.