### PR TITLE
2 packages from na4zagin3/SATySFi-fonts-bodoni-star at 2.3+satysfi0.0.5

### DIFF
--- a/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Document: SATySFi Font Package for Bodoni*"
+description: """
+Document: SATySFi Font Package for Bodoni*
+
+This package installs fonts from https://github.com/indestructible-type/Bodoni
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-bodoni-star.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-fonts-bodoni-star" {= "%{version}%"}
+
+  "satysfi-lipsum"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-bodoni-star-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-bodoni-star-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/archive/v2.3+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=76570308ea51248c8d008ba88833ada3"
+    "sha512=32001200503f134442fa7eda2dfad55a273466a86526dfe2d27c8a7fd17b7eca6792c6a0d6ea88c3ed255fa077257a74f326e30925fd1d589f9d588d5769ab46"
+  ]
+}

--- a/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Bodoni*"
+description: """
+SATySFi Font Package for Bodoni*
+
+This package installs fonts from https://github.com/indestructible-type/Bodoni
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star"
+bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/issues"
+dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-bodoni-star.git"
+extra-source "Bodoni-master.zip" {
+  archive: "https://github.com/indestructible-type/Bodoni/releases/download/2.3/Bodoni-master.zip"
+  checksum: [
+    "sha256=787426889302f357b1e108fd5284fbe9d40063cb0c994d936c7b6a99816f8ccc"
+    "sha512=6e669d9daf2aea3fbc9e0df3c7440ae6e5968d630b4849afca718bab65ab79bcbe5041a8393c534802b4b211d9d4e59f2e70b65aa7c194fcda81b65a2a48d77d"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-o" "Bodoni-master.zip"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-bodoni-star"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/archive/v2.3+satysfi0.0.5.tar.gz"
+  checksum: [
+    "md5=76570308ea51248c8d008ba88833ada3"
+    "sha512=32001200503f134442fa7eda2dfad55a273466a86526dfe2d27c8a7fd17b7eca6792c6a0d6ea88c3ed255fa077257a74f326e30925fd1d589f9d588d5769ab46"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -64,6 +64,10 @@ depends: [
 
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
 
+  "satysfi-fonts-bodoni-star-doc" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
 
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -60,6 +60,10 @@ depends: [
 
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
 
+  "satysfi-fonts-bodoni-star-doc" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
 
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-bodoni-star.2.3+satysfi0.0.5`: SATySFi Font Package for Bodoni*
-`satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5`: Document: SATySFi Font Package for Bodoni*



---
* Homepage: https://github.com/na4zagin3/SATySFi-fonts-bodoni-star
* Source repo: git+https://github.com/na4zagin3/SATySFi-fonts-bodoni-star.git
* Bug tracker: https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2