### PR TITLE
2 packages from puripuri2100/SATySFi-ruby at 0.1.2

### DIFF
--- a/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
+++ b/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Japanese-style ruby in SATySFi"
+description: """Japanese-style ruby in SATySFi."""
+
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-ruby"
+bug-reports: "https://github.com/puripuri2100/SATySFi-ruby/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-ruby.git"
+
+depends: [
+  "satysfi" {>= "0.0.1" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-ruby" {"%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+    "-name" "ruby-doc"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "ruby-doc"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-ruby/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=935b64abb374d5ec2148dc0086e8f2b4"
+    "sha512=ac9b85e74c56fd69b0d49f1d2b230e9ba7f810ec9134df15a9ea40bd46eb294b0903c33962444a0998c64877b6faf0d912c48deb42c4a183c01cb6c5d2f5e0f4"
+  ]
+}

--- a/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
+++ b/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
@@ -28,9 +28,9 @@ install: [
     "-script" "%{build}%/Satyristes"]
 ]
 url {
-  src: "https://github.com/puripuri2100/SATySFi-ruby/archive/0.1.1.tar.gz"
+  src: "https://github.com/puripuri2100/SATySFi-ruby/archive/0.1.2.tar.gz"
   checksum: [
-    "md5=935b64abb374d5ec2148dc0086e8f2b4"
-    "sha512=ac9b85e74c56fd69b0d49f1d2b230e9ba7f810ec9134df15a9ea40bd46eb294b0903c33962444a0998c64877b6faf0d912c48deb42c4a183c01cb6c5d2f5e0f4"
+    "md5=f7d79cc7bc45280d4869993f1ccebbb0"
+    "sha512=ff308d47163f32d22df9143c9066b019b105f34b3a3f0ba061f70a8f9d731f782dcdbda32068cd2aa13715020d8997ae298dc45c29a004afc09a116b02f5a538"
   ]
 }

--- a/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
+++ b/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Japanese-style ruby in SATySFi"
+description: """Japanese-style ruby in SATySFi."""
+
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-ruby"
+bug-reports: "https://github.com/puripuri2100/SATySFi-ruby/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-ruby.git"
+
+depends: [
+  "satysfi" {>= "0.0.1" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "ruby"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-ruby/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=935b64abb374d5ec2148dc0086e8f2b4"
+    "sha512=ac9b85e74c56fd69b0d49f1d2b230e9ba7f810ec9134df15a9ea40bd46eb294b0903c33962444a0998c64877b6faf0d912c48deb42c4a183c01cb6c5d2f5e0f4"
+  ]
+}

--- a/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
+++ b/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
@@ -23,7 +23,7 @@ install: [
 url {
   src: "https://github.com/puripuri2100/SATySFi-ruby/archive/0.1.1.tar.gz"
   checksum: [
-    "md5=935b64abb374d5ec2148dc0086e8f2b4"
-    "sha512=ac9b85e74c56fd69b0d49f1d2b230e9ba7f810ec9134df15a9ea40bd46eb294b0903c33962444a0998c64877b6faf0d912c48deb42c4a183c01cb6c5d2f5e0f4"
+    "md5=f7d79cc7bc45280d4869993f1ccebbb0"
+    "sha512=ff308d47163f32d22df9143c9066b019b105f34b3a3f0ba061f70a8f9d731f782dcdbda32068cd2aa13715020d8997ae298dc45c29a004afc09a116b02f5a538"
   ]
 }

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -140,7 +140,11 @@ depends: [
 
   "satysfi-ruby-doc" {= "0.1.1"}
 
+  "satysfi-ruby-doc" {= "0.1.2"}
+
   "satysfi-ruby" {= "0.1.1"}
+
+  "satysfi-ruby" {= "0.1.2"}
 
   "satysfi-simple-itemize" {= "1.0.0"}
 

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -100,7 +100,11 @@ depends: [
 
   "satysfi-ruby-doc" {= "0.1.1"}
 
+  "satysfi-ruby-doc" {= "0.1.2"}
+
   "satysfi-ruby" {= "0.1.1"}
+
+  "satysfi-ruby" {= "0.1.2"}
 
   "satysfi-simple-itemize" {= "1.0.0"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -136,7 +136,11 @@ depends: [
 
   "satysfi-ruby-doc" {= "0.1.1"}
 
+  "satysfi-ruby-doc" {= "0.1.2"}
+
   "satysfi-ruby" {= "0.1.1"}
+
+  "satysfi-ruby" {= "0.1.2"}
 
   "satysfi-simple-itemize" {= "1.0.0"}
 


### PR DESCRIPTION
Japanese-style ruby in SATySFi

This pull-request concerns:
-`satysfi-ruby.0.1.2`
-`satysfi-ruby-doc.0.1.2`



---
* Homepage: https://github.com/puripuri2100/SATySFi-ruby
* Source repo: git+https://github.com/puripuri2100/SATySFi-ruby.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-ruby/issues

---
:camel: Pull-request generated by opam-publish v2.0.2