### PR TITLE
2 packages from puripuri2100/SATySFi-fonts-noto-sans-cjk-sc at 2.001+1

### DIFF
--- a/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Noto Sans CJK SC fonts"
+description: """
+Document package for satysfi-fonts-noto-sans-cjk-sc
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+    "-name" "fonts-noto-sans-cjk-sc-doc"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "fonts-noto-sans-cjk-sc-doc"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/archive/2.001+1.tar.gz"
+  checksum: [
+    "md5=f32a189699b6405bac7f7a462c474629"
+    "sha512=b330d3e7687cca6cb5f14ff67b3f417ad47dba589b2d5ccb6e2f1d80048c1eaef1820bfbe292a6faf5f657f0ef7d5e8d4123b57c326cb4a8b6997563c1aab621"
+  ]
+}

--- a/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.gi
 depends: [
   "satysfi" {>= "0.0.4" & < "0.0.6"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001"}
+  "satysfi-fonts-noto-sans-cjk-sc" {= "%{version}%"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Noto Sans CJK SC fonts"
+description: """
+SATySFi font package for Noto Sans CJK SC fonts.
+
+This package installs fonts from https://www.google.com/get/noto/.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "OFL"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git"
+extra-source "noto-sans-cjk-sc.zip" {
+  archive: "https://github.com/puripuri2100/noto-cjk/releases/download/NotoSansV2.001/NotoSansCJKSc.zip"
+  checksum: [
+    "sha256=877dfb20cdb31c5a8f53782823b50766f3b1bbfc3e97fcd48bdd454b03745506"
+    "sha512=760afabc76302ffbcae2afaf9d59d4ed69084e3e793d10045a3ae40389721b2c9828dc49463088939e47530c34dbb06f6ffa3b14eab2058271f6dbd62338044f"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "noto-sans-cjk-sc" "-o" "noto-sans-cjk-sc.zip" "*.otf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "fonts-noto-sans-cjk-sc"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/archive/2.001+1.tar.gz"
+  checksum: [
+    "md5=f32a189699b6405bac7f7a462c474629"
+    "sha512=b330d3e7687cca6cb5f14ff67b3f417ad47dba589b2d5ccb6e2f1d80048c1eaef1820bfbe292a6faf5f657f0ef7d5e8d4123b57c326cb4a8b6997563c1aab621"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -92,6 +92,10 @@ depends: [
 
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
 
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
 
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}

--- a/snapshot-stable-0-0-4.opam
+++ b/snapshot-stable-0-0-4.opam
@@ -62,6 +62,10 @@ depends: [
 
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
 
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
 
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -88,6 +88,10 @@ depends: [
 
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
 
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
   "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
 
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-noto-sans-cjk-sc.2.001+1`: SATySFi Font Package for Noto Sans CJK SC fonts
-`satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1`: Document of SATySFi Font Package for Noto Sans CJK SC fonts



---
* Homepage: https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc
* Source repo: git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues

---
:camel: Pull-request generated by opam-publish v2.0.2