### PR TITLE
2 packages from monaqa/satysfi-azmath at 0.0.1

### DIFF
--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.1/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-azmath" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=ca6d61f129fa81418299ddf0a3f4fc26"
+    "sha512=6135a55d1909b4d04e2042a43908edc46c9c548f5648ecbbdfa375b3b308b066d5599711e760816dbd4182cdd2ff3026ff0ea0c6d27cdcbe5949ea82da91b607"
+  ]
+}

--- a/packages/satysfi-azmath/satysfi-azmath.0.0.1/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=ca6d61f129fa81418299ddf0a3f4fc26"
+    "sha512=6135a55d1909b4d04e2042a43908edc46c9c548f5648ecbbdfa375b3b308b066d5599711e760816dbd4182cdd2ff3026ff0ea0c6d27cdcbe5949ea82da91b607"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -20,6 +20,10 @@ depends: [
 
 # Package List
 
+  "satysfi-azmath-doc" {= "0.0.1"}
+
+  "satysfi-azmath" {= "0.0.1"}
+
   "satysfi-arrows-doc" {= "0.1.0"}
 
   "satysfi-arrows" {= "0.1.0"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -20,6 +20,10 @@ depends: [
 
 # Package List
 
+  "satysfi-azmath-doc" {= "0.0.1"}
+
+  "satysfi-azmath" {= "0.0.1"}
+
   "satysfi-assert-eq" {= "0.1.1"}
 
   "satysfi-base" {= "1.3.0"}


### PR DESCRIPTION
A SATySFi package containing A-to-Z mathematical commands

This pull-request concerns:
-`satysfi-azmath.0.0.1`
-`satysfi-azmath-doc.0.0.1`



---
* Homepage: https://github.com/monaqa/satysfi-azmath
* Source repo: git+https://github.com/monaqa/satysfi-azmath.git
* Bug tracker: https://github.com/monaqa/satysfi-azmath/issues

---
:camel: Pull-request generated by opam-publish v2.0.2