### PR TITLE
Fix distribution urls of IPAFont

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.09/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.09/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.16/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.16/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.22/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.22/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.05/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.25/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.25/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00401.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.06.07/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.06.07/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00401.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.4/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4/opam
@@ -27,7 +27,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00401.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
   ]

--- a/packages/satysfi-dist/satysfi-dist.0.0.5/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5/opam
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00401.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
   ]

--- a/packages/satysfi/satysfi.0.0.3/opam
+++ b/packages/satysfi/satysfi.0.0.3/opam
@@ -30,7 +30,7 @@ extra-source "junicode-1.002.zip" {
   ]
 }
 extra-source "IPAexfont00301.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00301.zip"
   ]

--- a/resources/satysfi-dist.template
+++ b/resources/satysfi-dist.template
@@ -25,7 +25,7 @@ extra-source "temp/junicode-1.002.zip" {
   ]
 }
 extra-source "temp/IPAexfont00401.zip" {
-  archive: "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
   mirrors: [
     "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
   ]


### PR DESCRIPTION
Distribution URLs of IPAFonts have been moved from `https://ipafont.ipa.go.jp/IPAexfont/*.zip` for `https://moji.or.jp/wp-content/ipafont/IPAexfont/*.zip`

See also:
- https://github.com/amutake/satysfi-docker/pull/26
- https://github.com/gfngfn/SATySFi/pull/240

Closes https://github.com/na4zagin3/satyrographos-repo/issues/206