### PR TITLE
Do not update satysfi-dist packages in the snapshots

### DIFF
--- a/scripts/update-snapshot
+++ b/scripts/update-snapshot
@@ -6,6 +6,7 @@ changed_packages () {
 		-e 's!packages/[^/]*/!!' \
 		-e 's!/opam$!!' \
 		-e '/^satyrographos[-.]/d' \
+		-e '/^satysfi-dist[.]/d' \
 		-e '/^satysfi[.]/d'
 }
 


### PR DESCRIPTION
This PR lets `update-snapshot` ignore changes on `satysfi-dist` packages