### PR TITLE
2 packages from puripuri2100/satysfi-tombo at 0.1.0

### DIFF
--- a/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.1.0/opam
+++ b/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document of Tombo Package"
+description: """
+Document of Tombo Package.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/puripuri2100/satysfi-tombo"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-tombo" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "tombo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "tombo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-tombo/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=e108d80b558a2ca7083eb2648560cd85"
+    "sha512=04447908d7de197c8e2f1d46e076301d535c1316d60656eb4063818ba090b57cba1cb4399cdee7432f5f45aa695ce772f31df92e79ec83b336dd3004b2d1e594"
+  ]
+}

--- a/packages/satysfi-tombo/satysfi-tombo.0.1.0/opam
+++ b/packages/satysfi-tombo/satysfi-tombo.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Generate Japanese-style crop marks"
+description: """
+Generate Japanese-style crop marks.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/satysfi-tombo"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "tombo"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-tombo/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=e108d80b558a2ca7083eb2648560cd85"
+    "sha512=04447908d7de197c8e2f1d46e076301d535c1316d60656eb4063818ba090b57cba1cb4399cdee7432f5f45aa695ce772f31df92e79ec83b336dd3004b2d1e594"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -20,15 +20,15 @@ depends: [
 
 # Package List
 
-  "satysfi-azmath-doc" {= "0.0.1"}
-
-  "satysfi-azmath" {= "0.0.1"}
-
   "satysfi-arrows-doc" {= "0.1.0"}
 
   "satysfi-arrows" {= "0.1.0"}
 
   "satysfi-assert-eq" {= "0.1.1"}
+
+  "satysfi-azmath-doc" {= "0.0.1"}
+
+  "satysfi-azmath" {= "0.0.1"}
 
   "satysfi-base" {= "1.3.0"}
 
@@ -134,6 +134,8 @@ depends: [
 
   "satysfi-make-markdown" {= "0.1.0"}
 
+  "satysfi-matrixcd" {= "0.0.1"}
+
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
 
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
@@ -153,6 +155,10 @@ depends: [
   "satysfi-simple-itemize" {= "1.0.0"}
 
   "satysfi-siunitx" {= "0.1"}
+
+  "satysfi-tombo-doc" {= "0.1.0"}
+
+  "satysfi-tombo" {= "0.1.0"}
 
   "satysfi-uline" {= "0.2.0"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -20,11 +20,11 @@ depends: [
 
 # Package List
 
+  "satysfi-assert-eq" {= "0.1.1"}
+
   "satysfi-azmath-doc" {= "0.0.1"}
 
   "satysfi-azmath" {= "0.0.1"}
-
-  "satysfi-assert-eq" {= "0.1.1"}
 
   "satysfi-base" {= "1.3.0"}
 
@@ -130,6 +130,8 @@ depends: [
 
   "satysfi-make-markdown" {= "0.1.0"}
 
+  "satysfi-matrixcd" {= "0.0.1"}
+
   "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
 
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
@@ -149,6 +151,10 @@ depends: [
   "satysfi-simple-itemize" {= "1.0.0"}
 
   "satysfi-siunitx" {= "0.1"}
+
+  "satysfi-tombo-doc" {= "0.1.0"}
+
+  "satysfi-tombo" {= "0.1.0"}
 
   "satysfi-uline" {= "0.2.0"}
 


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-tombo.0.1.0`: Generate Japanese-style crop marks
-`satysfi-tombo-doc.0.1.0`: Document of Tombo Package



---
* Homepage: https://github.com/puripuri2100/satysfi-tombo
* Source repo: git+https://github.com/puripuri2100/satysfi-tombo.git
* Bug tracker: https://github.com/puripuri2100/satysfi-tombo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2