### PR TITLE
2 packages from monaqa/satysfi-azmath at 0.0.2

### DIFF
--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.2/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-azmath" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.2.tar.gz"
+  checksum: [
+    "md5=ac1db77d081ec1ca4a6eacea78863096"
+    "sha512=bbb18a146dea922095a8797d7022276af018871d1a72102fcfbbbec8608dd8ee49c2a76eecd5d9353874631b40a586f642a2d3c68bbd9070ecf08ef6c0f9c8bd"
+  ]
+}

--- a/packages/satysfi-azmath/satysfi-azmath.0.0.2/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.2.tar.gz"
+  checksum: [
+    "md5=ac1db77d081ec1ca4a6eacea78863096"
+    "sha512=bbb18a146dea922095a8797d7022276af018871d1a72102fcfbbbec8608dd8ee49c2a76eecd5d9353874631b40a586f642a2d3c68bbd9070ecf08ef6c0f9c8bd"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -26,9 +26,9 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.1"}
 
-  "satysfi-azmath-doc" {= "0.0.1"}
+  "satysfi-azmath-doc" {= "0.0.2"}
 
-  "satysfi-azmath" {= "0.0.1"}
+  "satysfi-azmath" {= "0.0.2"}
 
   "satysfi-base" {= "1.3.0"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -22,9 +22,9 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.1"}
 
-  "satysfi-azmath-doc" {= "0.0.1"}
+  "satysfi-azmath-doc" {= "0.0.2"}
 
-  "satysfi-azmath" {= "0.0.1"}
+  "satysfi-azmath" {= "0.0.2"}
 
   "satysfi-base" {= "1.3.0"}
 


### PR DESCRIPTION
A SATySFi package containing A-to-Z mathematical commands

This pull-request concerns:
-`satysfi-azmath.0.0.2`
-`satysfi-azmath-doc.0.0.2`



---
* Homepage: https://github.com/monaqa/satysfi-azmath
* Source repo: git+https://github.com/monaqa/satysfi-azmath.git
* Bug tracker: https://github.com/monaqa/satysfi-azmath/issues

---
:camel: Pull-request generated by opam-publish v2.0.2