### PR TITLE
2 packages from monaqa/satysfi-azmath at 0.0.3

### DIFF
--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-azmath" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.3.tar.gz"
+  checksum: [
+    "md5=872911500b9ce8c45cb9e38fe5fe0b4b"
+    "sha512=725917ab03e5599f7ef2d5065afa904197bf58ddd61ebec0b7dd160f1bce1e60bbfe4fecddc40f753c6e33fc103fe5a0ef36d3fe9dcab58c40bb2236617b3812"
+  ]
+}

--- a/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.3.tar.gz"
+  checksum: [
+    "md5=872911500b9ce8c45cb9e38fe5fe0b4b"
+    "sha512=725917ab03e5599f7ef2d5065afa904197bf58ddd61ebec0b7dd160f1bce1e60bbfe4fecddc40f753c6e33fc103fe5a0ef36d3fe9dcab58c40bb2236617b3812"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -26,9 +26,9 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.1"}
 
-  "satysfi-azmath-doc" {= "0.0.1"}
+  "satysfi-azmath-doc" {= "0.0.3"}
 
-  "satysfi-azmath" {= "0.0.1"}
+  "satysfi-azmath" {= "0.0.3"}
 
   "satysfi-base" {= "1.3.0"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -22,9 +22,9 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.1"}
 
-  "satysfi-azmath-doc" {= "0.0.1"}
+  "satysfi-azmath-doc" {= "0.0.3"}
 
-  "satysfi-azmath" {= "0.0.1"}
+  "satysfi-azmath" {= "0.0.3"}
 
   "satysfi-base" {= "1.3.0"}
 


### PR DESCRIPTION
A SATySFi package containing A-to-Z mathematical commands

This pull-request concerns:
-`satysfi-azmath.0.0.3`
-`satysfi-azmath-doc.0.0.3`



---
* Homepage: https://github.com/monaqa/satysfi-azmath
* Source repo: git+https://github.com/monaqa/satysfi-azmath.git
* Bug tracker: https://github.com/monaqa/satysfi-azmath/issues

---
:camel: Pull-request generated by opam-publish v2.0.2