### PR TITLE
2 packages from puripuri2100/satysfi-tombo at 0.2.0

### DIFF
--- a/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.2.0/opam
+++ b/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document of Tombo Package"
+description: """
+Document of Tombo Package.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/puripuri2100/satysfi-tombo"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-tombo" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "tombo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "tombo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-tombo/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=723d3f427ab0ce0f61d4c690c00024c4"
+    "sha512=02073dcf740c009923363be165b7c40ae78e932b851c80d7a32e9bb735910c87a7dd9d89c0e879fa62f56e0e1ec59aad1e47dc77aae0ce3a91e6a49776730e76"
+  ]
+}

--- a/packages/satysfi-tombo/satysfi-tombo.0.2.0/opam
+++ b/packages/satysfi-tombo/satysfi-tombo.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Generate Japanese-style crop marks"
+description: """
+Generate Japanese-style crop marks.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/satysfi-tombo"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "tombo"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-tombo/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=723d3f427ab0ce0f61d4c690c00024c4"
+    "sha512=02073dcf740c009923363be165b7c40ae78e932b851c80d7a32e9bb735910c87a7dd9d89c0e879fa62f56e0e1ec59aad1e47dc77aae0ce3a91e6a49776730e76"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -156,9 +156,9 @@ depends: [
 
   "satysfi-siunitx" {= "0.1"}
 
-  "satysfi-tombo-doc" {= "0.1.0"}
+  "satysfi-tombo-doc" {= "0.2.0"}
 
-  "satysfi-tombo" {= "0.1.0"}
+  "satysfi-tombo" {= "0.2.0"}
 
   "satysfi-uline" {= "0.2.0"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -152,9 +152,9 @@ depends: [
 
   "satysfi-siunitx" {= "0.1"}
 
-  "satysfi-tombo-doc" {= "0.1.0"}
+  "satysfi-tombo-doc" {= "0.2.0"}
 
-  "satysfi-tombo" {= "0.1.0"}
+  "satysfi-tombo" {= "0.2.0"}
 
   "satysfi-uline" {= "0.2.0"}
 


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-tombo.0.2.0`: Generate Japanese-style crop marks
-`satysfi-tombo-doc.0.2.0`: Document of Tombo Package



---
* Homepage: https://github.com/puripuri2100/satysfi-tombo
* Source repo: git+https://github.com/puripuri2100/satysfi-tombo.git
* Bug tracker: https://github.com/puripuri2100/satysfi-tombo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2