### PR TITLE
2 packages from puripuri2100/SATySFi-textmode-latex-packages at 0.2.0

### DIFF
--- a/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
+++ b/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
@@ -17,15 +17,15 @@ depends: [
 ]
 build: [
   ["satyrographos" "opam" "build"
-   "-name" "make-latex-doc"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
+   "--name" "make-latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
 ]
 install: [
   ["satyrographos" "opam" "install"
-   "-name" "make-latex-doc"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
+   "--name" "make-latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
 ]
 url {
   src:

--- a/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
+++ b/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
@@ -17,15 +17,15 @@ depends: [
 ]
 build: [
   ["satyrographos" "opam" "build"
-   "--name" "make-latex-doc"
-   "--prefix" "%{prefix}%"
-   "--script" "%{build}%/Satyristes"]
+   "-name" "make-latex-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
 ]
 install: [
   ["satyrographos" "opam" "install"
-   "--name" "make-latex-doc"
-   "--prefix" "%{prefix}%"
-   "--script" "%{build}%/Satyristes"]
+   "-name" "make-latex-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
 ]
 url {
   src:

--- a/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
+++ b/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of make-latex Package"
+description: """
+Document of make-latex Package.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-make-latex"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-make-latex" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "make-latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "make-latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-textmode-latex-packages/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=9d27ec241cba55d4d726b20c09af8325"
+    "sha512=121763631562b340d3894585b86e2ffdcf1ecb299d6a86528c81d617e47c5f80e00ace40e10f32d429bcaad64342fcc44513721a61b6c98a10c67038b9866130"
+  ]
+}

--- a/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
+++ b/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
@@ -16,9 +16,9 @@ depends: [
 ]
 install: [
   ["satyrographos" "opam" "install"
-   "--name" "make-latex"
-   "--prefix" "%{prefix}%"
-   "--script" "%{build}%/Satyristes"]
+   "-name" "make-latex"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
 ]
 url {
   src:

--- a/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
+++ b/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Outputting LaTeX file using SATySFi's text-mode"
+description: """Outputting LaTeX file using SATySFi's text-mode."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-make-latex"
+bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "make-latex"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-textmode-latex-packages/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=9d27ec241cba55d4d726b20c09af8325"
+    "sha512=121763631562b340d3894585b86e2ffdcf1ecb299d6a86528c81d617e47c5f80e00ace40e10f32d429bcaad64342fcc44513721a61b6c98a10c67038b9866130"
+  ]
+}

--- a/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
+++ b/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
@@ -10,15 +10,15 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
 
 depends: [
-  "satysfi" {>= "0.0.3" & < "0.0.6"}
-  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.4"}
   "satysfi-dist"
 ]
 install: [
   ["satyrographos" "opam" "install"
-   "-name" "make-latex"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
+   "--name" "make-latex"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
 ]
 url {
   src:

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -132,6 +132,10 @@ depends: [
 
   "satysfi-make-html" {= "0.1.0"}
 
+  "satysfi-make-latex-doc" {= "0.2.0"}
+
+  "satysfi-make-latex" {= "0.2.0"}
+
   "satysfi-make-markdown" {= "0.1.0"}
 
   "satysfi-matrixcd" {= "0.0.1"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -128,6 +128,10 @@ depends: [
 
   "satysfi-make-html" {= "0.1.0"}
 
+  "satysfi-make-latex-doc" {= "0.2.0"}
+
+  "satysfi-make-latex" {= "0.2.0"}
+
   "satysfi-make-markdown" {= "0.1.0"}
 
   "satysfi-matrixcd" {= "0.0.1"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-make-latex.0.2.0`: Outputting LaTeX file using SATySFi's text-mode
-`satysfi-make-latex-doc.0.2.0`: Document of make-latex Package



---
* Homepage: https://github.com/puripuri2100/SATySFi-make-latex
* Source repo: git+https://github.com/puripuri2100/SATySFi-make-latex.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-make-latex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2