### PR TITLE
2 packages from puripuri2100/SATySFi-texlogo at 0.1.1

### DIFF
--- a/packages/satysfi-texlogo-doc/satysfi-texlogo-doc.0.1.1/opam
+++ b/packages/satysfi-texlogo-doc/satysfi-texlogo-doc.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Document of satysfi-texlogo"
+description: """
+Document of satysfi-texlogo.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/puripuri2100/SATySFi-texlogo"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-texlogo.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-texlogo/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-texlogo" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-easytable"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "texlogo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "texlogo-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-texlogo/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=3905149d049520c940116980bdd6e7c9"
+    "sha512=cb93c3b5188098fff6eda598d6ab70a049f5b31fe4872364ab7a39a25accc55693387a58e579cc8cdb518b5b225168db823f136587cde4951c5755b8a53b00af"
+  ]
+}

--- a/packages/satysfi-texlogo/satysfi-texlogo.0.1.1/opam
+++ b/packages/satysfi-texlogo/satysfi-texlogo.0.1.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "TeX-family logos with SATySFi"
+description: """
+TeX-family logos with SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-texlogo"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-texlogo.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-texlogo/issues"
+depends: [
+  "satysfi" { >= "0.0.3" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "texlogo"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-texlogo/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=3905149d049520c940116980bdd6e7c9"
+    "sha512=cb93c3b5188098fff6eda598d6ab70a049f5b31fe4872364ab7a39a25accc55693387a58e579cc8cdb518b5b225168db823f136587cde4951c5755b8a53b00af"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -160,6 +160,10 @@ depends: [
 
   "satysfi-siunitx" {= "0.1"}
 
+  "satysfi-texlogo-doc" {= "0.1.1"}
+
+  "satysfi-texlogo" {= "0.1.1"}
+
   "satysfi-tombo-doc" {= "0.2.0"}
 
   "satysfi-tombo" {= "0.2.0"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -156,6 +156,10 @@ depends: [
 
   "satysfi-siunitx" {= "0.1"}
 
+  "satysfi-texlogo-doc" {= "0.1.1"}
+
+  "satysfi-texlogo" {= "0.1.1"}
+
   "satysfi-tombo-doc" {= "0.2.0"}
 
   "satysfi-tombo" {= "0.2.0"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-texlogo.0.1.1`: TeX-family logos with SATySFi
-`satysfi-texlogo-doc.0.1.1`: Document of satysfi-texlogo



---
* Homepage: https://github.com/puripuri2100/SATySFi-texlogo
* Source repo: git+https://github.com/puripuri2100/SATySFi-texlogo.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-texlogo/issues

---
:camel: Pull-request generated by opam-publish v2.0.2