### PR TITLE
2 packages from puripuri2100/SATySFi-md2latex at 0.0.1

### DIFF
--- a/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.1/opam
+++ b/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of md2latex Package"
+description: """
+Document of md2latex Package.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-md2latex" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "md2latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "md2latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-md2latex/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=e480d1da2d8e7643a6fe20f079bb3c2c"
+    "sha512=b4232477df8c67f7dc988ef3ca7cd2979d6e8347e9fafc38583adbd0445656167b2d381875916dcf26023b9b0c7988bf902021151a0604a2c6a2f6ad868937ff"
+  ]
+}

--- a/packages/satysfi-md2latex/satysfi-md2latex.0.0.1/opam
+++ b/packages/satysfi-md2latex/satysfi-md2latex.0.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Convert Markdown to LaTeX with SATySFi"
+description: """
+Convert Markdown to LaTeX with SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-make-latex" {>= "0.2.0" & < "0.3.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "md2latex"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-md2latex/archive/0.0.1.tar.gz"
+  checksum: [
+    "md5=e480d1da2d8e7643a6fe20f079bb3c2c"
+    "sha512=b4232477df8c67f7dc988ef3ca7cd2979d6e8347e9fafc38583adbd0445656167b2d381875916dcf26023b9b0c7988bf902021151a0604a2c6a2f6ad868937ff"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -144,6 +144,10 @@ depends: [
 
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
 
+  "satysfi-md2latex-doc" {= "0.0.1"}
+
+  "satysfi-md2latex" {= "0.0.1"}
+
   "satysfi-musikui" {= "0.1.0"}
 
   "satysfi-ncsq-doc" {= "2.1.0"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -140,6 +140,10 @@ depends: [
 
   "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
 
+  "satysfi-md2latex-doc" {= "0.0.1"}
+
+  "satysfi-md2latex" {= "0.0.1"}
+
   "satysfi-musikui" {= "0.1.0"}
 
   "satysfi-ncsq-doc" {= "2.0.0"}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-md2latex.0.0.1`: Convert Markdown to LaTeX with SATySFi
-`satysfi-md2latex-doc.0.0.1`: Document of md2latex Package



---
* Homepage: https://github.com/puripuri2100/SATySFi-md2latex
* Source repo: git+https://github.com/puripuri2100/SATySFi-md2latex.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-md2latex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2