### PR TITLE
2 packages from na4zagin3/satysfi-fss at 0.1.0

### DIFF
--- a/packages/satysfi-fss-doc/satysfi-fss-doc.0.1.0/opam
+++ b/packages/satysfi-fss-doc/satysfi-fss-doc.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document: Font selection scheme"
+description: """
+Document: Font selection scheme for SATySFi
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "LGPL-3.0-or-later" # Choose what you want
+homepage: "https://github.com/na4zagin3/satysfi-fss"
+dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-fss" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fss-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fss-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/na4zagin3/satysfi-fss/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=a67a80bace3f531e76b32169e91cf3bf"
+    "sha512=26d8341df4ef1ebc9e2ce8df4488a49f6fa932620b3d4d3961c290a6a0d6438d44e7c3d12330b9275ba93c663e3513a31e1b3825833aea2f63e6a40f5b81e360"
+  ]
+}

--- a/packages/satysfi-fss/satysfi-fss.0.1.0/opam
+++ b/packages/satysfi-fss/satysfi-fss.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Font selection scheme"
+description: """
+Document: Font selection scheme for SATySFi
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/na4zagin3/satysfi-fss"
+dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-base" {>= "1.3.0" & < "2"}
+  "satysfi-fonts-junicode" {>= "1" & < "2"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fss"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fss"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/na4zagin3/satysfi-fss/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=a67a80bace3f531e76b32169e91cf3bf"
+    "sha512=26d8341df4ef1ebc9e2ce8df4488a49f6fa932620b3d4d3961c290a6a0d6438d44e7c3d12330b9275ba93c663e3513a31e1b3825833aea2f63e6a40f5b81e360"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fss.0.1.0`: Font selection scheme
-`satysfi-fss-doc.0.1.0`: Document: Font selection scheme



---
* Homepage: https://github.com/na4zagin3/satysfi-fss
* Source repo: git+https://github.com/na4zagin3/satysfi-fss.git
* Bug tracker: https://github.com/na4zagin3/satysfi-fss/issues

---
:camel: Pull-request generated by opam-publish v2.0.2