### PR TITLE
Backport patch to download-fonts.sh

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/files/fix-download-font-sh-shasum.patch
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/files/fix-download-font-sh-shasum.patch
@@ -1,0 +1,31 @@
+diff --git a/download-fonts.sh b/download-fonts.sh
+index e4a9aee..9435212 100755
+--- a/download-fonts.sh
++++ b/download-fonts.sh
+@@ -4,8 +4,6 @@ set -ue
+ 
+ CACHE=temp
+ MESSAGE_PREFIX="[download-fonts.sh]"
+-SHA1SUM=sha1sum
+-
+ cd "$(dirname "$0")"
+ mkdir -p "$CACHE"
+ 
+@@ -13,6 +11,17 @@ show_message () {
+   echo "$MESSAGE_PREFIX $1."
+ }
+ 
++if command shasum --version >/dev/null 2>&1 ; then
++  show_message "Using shasum"
++  SHA1SUM=shasum
++elif command sha1sum --version >/dev/null 2>&1 ; then
++  show_message "Using sha1sum"
++  SHA1SUM=sha1sum
++else
++  echo "No SHA checksum checkers found.  Please install shasum or sha1sum" >&2
++  exit 1
++fi
++
+ validate_file () {
+   (
+ 	NAME="$1"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
@@ -52,8 +52,16 @@ depends: [
 synopsis: "Standard library of SATySFi"
 description: """
 Provides the standard library of SATySFi"""
-extra-files: ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
-patches: ["fix-install-libs.patch"]
+extra-files: [
+  ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
+  ["fix-download-font-sh-shasum.patch"
+  "sha512=ad58d4921a4b5ff9ece268280e0fdac396a6761eb92c2735c0d9905715abcfc729ecaa1ed503b0de52c56cbbd6e82baaaa11e6381deec8698adf2a184c559d91"
+  ]
+]
+patches: [
+  "fix-install-libs.patch"
+  "fix-download-font-sh-shasum.patch"
+]
 url {
   git: "git+https://github.com/gfngfn/SATySFi.git#4e8ea2147f66b8c26a494067b3011e480be6526e"
 }

--- a/packages/satysfi-dist/satysfi-dist.0.0.5/files/fix-download-font-sh-shasum.patch
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5/files/fix-download-font-sh-shasum.patch
@@ -1,0 +1,31 @@
+diff --git a/download-fonts.sh b/download-fonts.sh
+index e4a9aee..9435212 100755
+--- a/download-fonts.sh
++++ b/download-fonts.sh
+@@ -4,8 +4,6 @@ set -ue
+ 
+ CACHE=temp
+ MESSAGE_PREFIX="[download-fonts.sh]"
+-SHA1SUM=sha1sum
+-
+ cd "$(dirname "$0")"
+ mkdir -p "$CACHE"
+ 
+@@ -13,6 +11,17 @@ show_message () {
+   echo "$MESSAGE_PREFIX $1."
+ }
+ 
++if command shasum --version >/dev/null 2>&1 ; then
++  show_message "Using shasum"
++  SHA1SUM=shasum
++elif command sha1sum --version >/dev/null 2>&1 ; then
++  show_message "Using sha1sum"
++  SHA1SUM=sha1sum
++else
++  echo "No SHA checksum checkers found.  Please install shasum or sha1sum" >&2
++  exit 1
++fi
++
+ validate_file () {
+   (
+ 	NAME="$1"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5/opam
@@ -52,8 +52,16 @@ depends: [
 synopsis: "Standard library of SATySFi"
 description: """
 Provides the standard library of SATySFi"""
-extra-files: ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
-patches: ["fix-install-libs.patch"]
+extra-files: [
+  ["fix-install-libs.patch" "sha256=80e88dcb9d4fb6f5bb0d22d785906b91731cbaea9e7ff0b19c9084d8a50d35c8"]
+  ["fix-download-font-sh-shasum.patch"
+  "sha512=ad58d4921a4b5ff9ece268280e0fdac396a6761eb92c2735c0d9905715abcfc729ecaa1ed503b0de52c56cbbd6e82baaaa11e6381deec8698adf2a184c559d91"
+  ]
+]
+patches: [
+  "fix-install-libs.patch"
+  "fix-download-font-sh-shasum.patch"
+]
 url {
   src: "https://github.com/gfngfn/SATySFi/archive/v0.0.5.tar.gz"
   checksum: [


### PR DESCRIPTION
This commit backports https://github.com/gfngfn/SATySFi/pull/253

Closes https://github.com/na4zagin3/satyrographos-repo/issues/231

Fixes https://github.com/monaqa/slydifi/issues/15