### PR TITLE
Package satysfi-base.1.4.0

### DIFF
--- a/packages/satysfi-base/satysfi-base.1.4.0/opam
+++ b/packages/satysfi-base/satysfi-base.1.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A collection of utility functions and modules for SATySFi"
+description: """
+This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+authors: [
+  "Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>"
+  "puripuri2100 <puripuri2100@gmail.com>"
+  "Yuito Murase <yuito.murase@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/nyuichi/satysfi-base"
+bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
+dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-fonts-dejavu" {>= "2.37"}
+  "satysfi-zrbase" {>= "0.4.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "base"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/nyuichi/satysfi-base/archive/1.4.0.tar.gz"
+  checksum: [
+    "md5=e37208669b2ec82a5be0d2db1421baf8"
+    "sha512=562bd08919a74d44cc91ee48240e55f482a4d6c152a67a2dcb7bfe78947e698625190153723ecc92805e39cda7d18c46d36357d6dc711c5f9426388726a4b55f"
+  ]
+}


### PR DESCRIPTION
### `satysfi-base.1.4.0`
A collection of utility functions and modules for SATySFi
This is a collection of utility functions and modules for SATySFi. Because the library bundled with the default installation configuration of SATySFi is currently not rich enough, this project aims to provide a complementary library sufficient for most situations in typesetting.

this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.



---
* Homepage: https://github.com/nyuichi/satysfi-base
* Source repo: git+https://github.com/nyuichi/satysfi-base.git
* Bug tracker: https://github.com/nyuichi/satysfi-base/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups

- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)