### PR TITLE
2 packages from yabaitechtokyo/satysfi-class-yabaitech at 0.0.7

### DIFF
--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.7/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.7/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document: The yabaitech.tokyo SATySFi class file"
+description: """
+Document: The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: "Yuito Murase <yuito@acupof.coffee>"
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-class-yabaitech" {= "0.0.7"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "class-yabaitech-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-yabaitech-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.7.tar.gz"
+  checksum: [
+    "md5=1d9adbc054be2b72891ee1afa016d9cb"
+    "sha512=6ba6e3ba5ce016d700fcdb34ab75217df52db993e5f09f13b1b4826a46f63f793eb311dabd5da62599d908ea9f632cf460eed6a47e05e3efd70437635fc80154"
+  ]
+}

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.7/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.7/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "The yabaitech.tokyo SATySFi class file"
+description: """
+The yabaitech.tokyo SATySFi class file.
+
+This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "Yuito Murase <yuito@acupof.coffee>"
+authors: [
+    "gfngfn"
+    "Masaki Waga"
+    "Yuichi Nishiwaki <yuichi.nishiwaki@icloud.com>"
+    "Yuito Murase <yuito@acupof.coffee>"
+]
+license: "MIT"
+homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
+bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
+dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-base" {>= "1.2.1" & < "2.0.0"}
+  "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-sans-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-noto-serif-cjk-jp" {>= "2.001+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-yabaitech"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/archive/0.0.7.tar.gz"
+  checksum: [
+    "md5=1d9adbc054be2b72891ee1afa016d9cb"
+    "sha512=6ba6e3ba5ce016d700fcdb34ab75217df52db993e5f09f13b1b4826a46f63f793eb311dabd5da62599d908ea9f632cf460eed6a47e05e3efd70437635fc80154"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -50,9 +50,9 @@ depends: [
 
   "satysfi-class-stjarticle" {= "1.3.2"}
 
-  "satysfi-class-yabaitech-doc" {= "0.0.6"}
+  "satysfi-class-yabaitech-doc" {= "0.0.7"}
 
-  "satysfi-class-yabaitech" {= "0.0.6"}
+  "satysfi-class-yabaitech" {= "0.0.7"}
 
   "satysfi-debug-show-value" {= "0.1.1"}
 

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -46,9 +46,9 @@ depends: [
 
   "satysfi-class-stjarticle" {= "1.3.2"}
 
-  "satysfi-class-yabaitech-doc" {= "0.0.6"}
+  "satysfi-class-yabaitech-doc" {= "0.0.7"}
 
-  "satysfi-class-yabaitech" {= "0.0.6"}
+  "satysfi-class-yabaitech" {= "0.0.7"}
 
   "satysfi-debug-show-value" {= "0.1.1"}
 


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-class-yabaitech.0.0.7`: The yabaitech.tokyo SATySFi class file
-`satysfi-class-yabaitech-doc.0.0.7`: Document: The yabaitech.tokyo SATySFi class file



---
* Homepage: https://github.com/yabaitechtokyo/satysfi-class-yabaitech
* Source repo: git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git
* Bug tracker: https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues

---
:camel: Pull-request generated by opam-publish v2.0.2