### PR TITLE
Relax version constraint of satysfi-matrixcd

### DIFF
--- a/packages/satysfi-matrixcd/satysfi-matrixcd.0.0.2/opam
+++ b/packages/satysfi-matrixcd/satysfi-matrixcd.0.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "BSD-2-Clause-FreeBSD"
 depends: [
   "satysfi" {>= "0.0.4" & < "0.0.6"}
-  "satysfi-base" {= "1.3.0"}
+  "satysfi-base" {>= "1.3.0" & < "2.0.0"}
   "satyrographos" {>= "0.0.2.0" & < "0.0.3.0"}
 ]
 install: [


### PR DESCRIPTION
This PR allows satysfi-matrixcd to use satysfi-base 1.4.0 too
# Automatic follow-ups

- [x] Add to snapshot `snapshot-develop`: satysfi-matrixcd.0.0.2
- [x] Add to snapshot `snapshot-stable-0-0-4`: satysfi-matrixcd.0.0.2
- [x] Add to snapshot `snapshot-stable-0-0-5`: satysfi-matrixcd.0.0.2
- Add to snapshot ``