### PR TITLE
Packages satysfi-fonts-charis-sil.1.0.0 and satysfi-fonts-charis-sil-doc.1.0.0

### DIFF
--- a/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
@@ -29,3 +29,11 @@ install: [
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
+url {
+  src:
+    "https://github.com/yuhr/satysfi-fonts-charis-sil/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=738e8783abe0522fc4f67dbd1b7045dc"
+    "sha512=bc56c9a07d86d9586da1026434866665e8c9957d4619937011123b362fdce643665ca21bed3cc6fbed14a131023977b140de12af5beb2bbf53d29a15ff37329d"
+  ]
+}

--- a/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Charis SIL"
+description: """
+Document of SATySFi Font Package for Charis SIL
+
+This package demonstrates a usage of `satysfi-fonts-charis-sil`.
+"""
+maintainer: "Yu Shimura <mail@yuhr.org>"
+authors: "Yu Shimura <mail@yuhr.org>"
+license: "MIT"
+homepage: "https://github.com/yuhr/satysfi-fonts-charis-sil"
+bug-reports: "https://github.com/yuhr/satysfi-fonts-charis-sil/issues"
+dev-repo: "git+https://github.com/yuhr/satysfi-fonts-charis-sil.git"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-fonts-charis-sil" {= "%{version}%"}
+  "satysfi-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-charis-sil-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "fonts-charis-sil-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]

--- a/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Charis SIL"
+description: """
+SATySFi Font Package for Charis SIL
+
+This package installs fonts from https://software.sil.org/charis/.
+"""
+maintainer: "Yu Shimura <mail@yuhr.org>"
+authors: "Yu Shimura <mail@yuhr.org>"
+license: "MIT"
+homepage: "https://github.com/yuhr/satysfi-fonts-charis-sil"
+bug-reports: "https://github.com/yuhr/satysfi-fonts-charis-sil/issues"
+dev-repo: "git+https://github.com/yuhr/satysfi-fonts-charis-sil.git"
+extra-source "CharisSIL-5.000.zip" {
+  archive: "https://software.sil.org/downloads/r/charis/CharisSIL-5.000.zip"
+  checksum: [
+    "sha256=5e3e5473b30363008c289cc87e2aa584a0916087a63a3f689defa8e0cee09bfd"
+    "sha512=f85da6c9b93c0ef81617241219b208ca262c12fcecae1d447163b7aff31ea8bfc3f09636dcfc0a322c86201a0d551288884e4017fded5bb71bbb54c8093faaed"
+  ]
+}
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.6" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+]
+build: [
+  ["unzip" "-j" "-o" "CharisSIL-5.000.zip" "*.ttf" "-d" "charis-sil"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-charis-sil"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]

--- a/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
@@ -7,7 +7,7 @@ This package installs fonts from https://software.sil.org/charis/.
 """
 maintainer: "Yu Shimura <mail@yuhr.org>"
 authors: "Yu Shimura <mail@yuhr.org>"
-license: "MIT"
+license: "OFL-1.0"
 homepage: "https://github.com/yuhr/satysfi-fonts-charis-sil"
 bug-reports: "https://github.com/yuhr/satysfi-fonts-charis-sil/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-fonts-charis-sil.git"
@@ -31,3 +31,11 @@ install: [
    "--prefix" "%{prefix}%"
    "--script" "%{build}%/Satyristes"]
 ]
+url {
+  src:
+    "https://github.com/yuhr/satysfi-fonts-charis-sil/archive/v1.0.0.tar.gz"
+  checksum: [
+    "md5=738e8783abe0522fc4f67dbd1b7045dc"
+    "sha512=bc56c9a07d86d9586da1026434866665e8c9957d4619937011123b362fdce643665ca21bed3cc6fbed14a131023977b140de12af5beb2bbf53d29a15ff37329d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-charis-sil.1.0.0`: SATySFi Font Package for Charis SIL
-`satysfi-fonts-charis-sil-doc.1.0.0`: Document of SATySFi Font Package for Charis SIL



---
* Homepage: https://github.com/yuhr/satysfi-fonts-charis-sil
* Source repo: git+https://github.com/yuhr/satysfi-fonts-charis-sil.git
* Bug tracker: https://github.com/yuhr/satysfi-fonts-charis-sil/issues

---
:camel: Pull-request generated by opam-publish v2.0.3

👇I don't understand what I am supposed to do for this. What do you mean by "choose"?

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-fonts-charis-sil-doc.1.0.0 satysfi-fonts-charis-sil.1.0.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-fonts-charis-sil-doc.1.0.0 satysfi-fonts-charis-sil.1.0.0