### PR TITLE
Follow up #255

### DIFF
--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -74,6 +74,10 @@ depends: [
 
   "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
 
+  "satysfi-fonts-charis-sil-doc" {= "1.0.0"}
+
+  "satysfi-fonts-charis-sil" {= "1.0.0"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
 
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}

--- a/snapshot-stable-0-0-5.opam
+++ b/snapshot-stable-0-0-5.opam
@@ -70,6 +70,10 @@ depends: [
 
   "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
 
+  "satysfi-fonts-charis-sil-doc" {= "1.0.0"}
+
+  "satysfi-fonts-charis-sil" {= "1.0.0"}
+
   "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
 
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}


### PR DESCRIPTION
This PR follows up #255.

Adds satysfi-fonts-charis-sil-doc.1.0.0 satysfi-fonts-charis-sil.1.0.0 to develop and stable-0.0.5 snapshots
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)