### PR TITLE
2 packages from puripuri2100/SATySFi-fonts-inconsolata at 3.001

### DIFF
--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
 depends: [
   "satysfi" {>= "0.0.4" & < "0.0.6"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-fonts-inconsolata" { = "%{version}%" }
 ]
 build: [

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -12,6 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
 depends: [
   "satysfi" {>= "0.0.4" & < "0.0.6"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
   "satysfi-fonts-inconsolata" { = "%{version}%" }
 ]
 build: [

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for inconsolata fonts"
+description: """
+Document package for satysfi-fonts-inconsolata
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-inconsolata" { = "%{version}%" }
+]
+build: [
+  ["satyrographos" "opam" "build"
+    "--name" "fonts-inconsolata-doc"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "--name" "fonts-inconsolata-doc"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/archive/3.001.tar.gz"
+  checksum: [
+    "md5=dbdce672297d5a2d152cb20ba3236867"
+    "sha512=833da5b706231db2e487346195189408b3a6fe0edb13da94317dc32d7955c385a3dc21b1a803f6cc05a531dd6d3471567a6132602725108f1b99c2bbf13ab48c"
+  ]
+}

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -13,6 +13,7 @@ depends: [
   "satysfi" {>= "0.0.4" & < "0.0.6"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
+  "satysfi-dist"
   "satysfi-fonts-inconsolata" { = "%{version}%" }
 ]
 build: [

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
 depends: [
-  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-dist"

--- a/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for inconsolata fonts"
+description: """
+SATySFi font package for inconsolata fonts.
+
+This package installs fonts from https://www.google.com/get/noto/.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "OFL-1.1"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
+extra-source "inconsolata.zip" {
+  archive: "https://github.com/puripuri2100/inconsolata/archive/v3.001.zip"
+  checksum: [
+    "sha256=00d03451f5cb54b6a8276e788fdf2db227c432f78b3c4ecf6a3020c63ea451ab"
+    "sha512=f1c6708d22da2c8b8c935b8be2433c6bd1809330e35f185ec27a03bbdb5d7fcca4055747d1ff9cc9d0a85a442bfda7dafc94b6ead79f713aa7d95a0b1f229f9a"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "inconsolata" "-o" "inconsolata.zip" "*.ttf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "--name" "fonts-inconsolata"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/archive/3.001.tar.gz"
+  checksum: [
+    "md5=dbdce672297d5a2d152cb20ba3236867"
+    "sha512=833da5b706231db2e487346195189408b3a6fe0edb13da94317dc32d7955c385a3dc21b1a803f6cc05a531dd6d3471567a6132602725108f1b99c2bbf13ab48c"
+  ]
+}

--- a/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
@@ -19,7 +19,7 @@ extra-source "inconsolata.zip" {
   ]
 }
 depends: [
-  "satysfi" {>= "0.0.4" & < "0.0.6"}
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-inconsolata.3.001`: SATySFi Font Package for inconsolata fonts
-`satysfi-fonts-inconsolata-doc.3.001`: Document of SATySFi Font Package for inconsolata fonts



---
* Homepage: https://github.com/puripuri2100/SATySFi-fonts-inconsolata
* Source repo: git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] [ ] Add to snapshot `snapshot-develop` :: satysfi-fonts-inconsolata-doc.3.001 satysfi-fonts-inconsolata.3.001 :: satysfi-fonts-inconsolata-doc.3.001 satysfi-fonts-inconsolata.3.001
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-fonts-inconsolata-doc.3.001 satysfi-fonts-inconsolata.3.001 :: satysfi-fonts-inconsolata-doc.3.001 satysfi-fonts-inconsolata.3.001