### PR TITLE
2 packages from puripuri2100/SATySFi-assert-eq at 0.1.2

### DIFF
--- a/packages/satysfi-assert-eq-doc/satysfi-assert-eq-doc.0.1.2/opam
+++ b/packages/satysfi-assert-eq-doc/satysfi-assert-eq-doc.0.1.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document: Provides function as the Rust's assert_eq! macro"
+description: """Document: Provides function as the Rust's assert_eq! macro"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-assert-eq"
+bug-reports: "https://github.com/puripuri2100/SATySFi-assert-eq/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-assert-eq.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+
+  "satysfi-assert-eq" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "assert-eq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "assert-eq-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-assert-eq/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=39c39ca388cebb1d0990c96fd5fd2f08"
+    "sha512=0711d1c258a0e548725a1c6aa66fbf4fbd4c793103e9a9dfb7b22328ec7aab5fd272ea16dfe4e518a6b4afa68db872bf4b7255ca194eee41987d7c0330f6800f"
+  ]
+}

--- a/packages/satysfi-assert-eq/satysfi-assert-eq.0.1.2/opam
+++ b/packages/satysfi-assert-eq/satysfi-assert-eq.0.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Provides function as the Rust's assert_eq! macro"
+description: """Provides function as the Rust's assert_eq! macro"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-assert-eq"
+bug-reports: "https://github.com/puripuri2100/SATySFi-assert-eq/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-assert-eq.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "assert-eq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-assert-eq/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=39c39ca388cebb1d0990c96fd5fd2f08"
+    "sha512=0711d1c258a0e548725a1c6aa66fbf4fbd4c793103e9a9dfb7b22328ec7aab5fd272ea16dfe4e518a6b4afa68db872bf4b7255ca194eee41987d7c0330f6800f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-assert-eq.0.1.2`: Provides function as the Rust's assert_eq! macro
-`satysfi-assert-eq-doc.0.1.2`: Document: Provides function as the Rust's assert_eq! macro



---
* Homepage: https://github.com/puripuri2100/SATySFi-assert-eq
* Source repo: git+https://github.com/puripuri2100/SATySFi-assert-eq.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-assert-eq/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-assert-eq-doc.0.1.2 satysfi-assert-eq.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-4` :: satysfi-assert-eq-doc.0.1.2 satysfi-assert-eq.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-assert-eq-doc.0.1.2 satysfi-assert-eq.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-assert-eq-doc.0.1.2 satysfi-assert-eq.0.1.2