### PR TITLE
2 packages from puripuri2100/SATySFi-debug-show-value at 0.1.2

### DIFF
--- a/packages/satysfi-debug-show-value-doc/satysfi-debug-show-value-doc.0.1.2/opam
+++ b/packages/satysfi-debug-show-value-doc/satysfi-debug-show-value-doc.0.1.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document: Stringify SATySFi's value"
+description: """Document: Stringify SATySFi's value"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-debug-show-value"
+bug-reports: "https://github.com/puripuri2100/SATySFi-debug-show-value/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-debug-show-value.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+
+  "satysfi-debug-show-value" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "debug-show-value-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "debug-show-value-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-debug-show-value/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=25befd9318e7ca05d21b68498cf0ceb0"
+    "sha512=0eae59d1a2bd7b0bc62b8201cc5a378f4b646a0339227f06970270387b56039cbe709e262271466850137367501f43284e039e0606b18b6b60e73577d79eb547"
+  ]
+}

--- a/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
+++ b/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Stringify SATySFi's value"
+description: """Stringify SATySFi's value"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-debug-show-value"
+bug-reports: "https://github.com/puripuri2100/SATySFi-debug-show-value/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-debug-show-value.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "debug-show-value"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-debug-show-value/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=25befd9318e7ca05d21b68498cf0ceb0"
+    "sha512=0eae59d1a2bd7b0bc62b8201cc5a378f4b646a0339227f06970270387b56039cbe709e262271466850137367501f43284e039e0606b18b6b60e73577d79eb547"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-debug-show-value.0.1.2`: Stringify SATySFi's value
-`satysfi-debug-show-value-doc.0.1.2`: Document: Stringify SATySFi's value



---
* Homepage: https://github.com/puripuri2100/SATySFi-debug-show-value
* Source repo: git+https://github.com/puripuri2100/SATySFi-debug-show-value.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-debug-show-value/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-debug-show-value-doc.0.1.2 satysfi-debug-show-value.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-4` :: satysfi-debug-show-value-doc.0.1.2 satysfi-debug-show-value.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-debug-show-value-doc.0.1.2 satysfi-debug-show-value.0.1.2
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-debug-show-value-doc.0.1.2 satysfi-debug-show-value.0.1.2