### PR TITLE
2 packages from monaqa/satysfi-easytable at 1.1.0

### DIFF
--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.0/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-easytable" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.0.tar.gz"
+  checksum: [
+    "md5=cdfeacf74de336c15bd826c46f1e77bf"
+    "sha512=7e146a6bf123fac9e98220e5f1487abc5077fb7d8c4f5bf1c0ee520e136d428a45eb1d8755ca137aecfdac156eb21967d8e56da19edca94d64d1eb9267ae3638"
+  ]
+}

--- a/packages/satysfi-easytable/satysfi-easytable.1.1.0/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.0.tar.gz"
+  checksum: [
+    "md5=cdfeacf74de336c15bd826c46f1e77bf"
+    "sha512=7e146a6bf123fac9e98220e5f1487abc5077fb7d8c4f5bf1c0ee520e136d428a45eb1d8755ca137aecfdac156eb21967d8e56da19edca94d64d1eb9267ae3638"
+  ]
+}


### PR DESCRIPTION
A SATySFi package to build simple tables

This pull-request concerns:
-`satysfi-easytable.1.1.0`
-`satysfi-easytable-doc.1.1.0`



---
* Homepage: https://github.com/monaqa/satysfi-easytable
* Source repo: git+https://github.com/monaqa/satysfi-easytable.git
* Bug tracker: https://github.com/monaqa/satysfi-easytable/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- Add to snapshot `snapshot-stable-0-0-4`
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`