### PR TITLE
2 packages from puripuri2100/SATySFi-lipsum at 0.2.1

### DIFF
--- a/packages/satysfi-lipsum-doc/satysfi-lipsum-doc.0.2.1/opam
+++ b/packages/satysfi-lipsum-doc/satysfi-lipsum-doc.0.2.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document: A SATySFi package of dummy text"
+description: """Document: A SATySFi package of dummy text."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-lipsum"
+bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
+
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-lipsum" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "lipsum-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "lipsum-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-lipsum/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=4d133b354a4c0023a4c0d1acd2640f27"
+    "sha512=459ffd0531194913feb6e47607b2f8e67937bfdd78f7e0571da658b2bfe66515500529acb3a8bc87719e53ef98c77fa43070de838dd19c943db8eadc6a98c3a8"
+  ]
+}

--- a/packages/satysfi-lipsum/satysfi-lipsum.0.2.1/opam
+++ b/packages/satysfi-lipsum/satysfi-lipsum.0.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package of dummy text"
+description: """A SATySFi package of dummy text."""
+
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
+authors: "puripuri2100 <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-lipsum"
+bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
+
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "-name" "lipsum"
+    "-prefix" "%{prefix}%"
+    "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-lipsum/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=4d133b354a4c0023a4c0d1acd2640f27"
+    "sha512=459ffd0531194913feb6e47607b2f8e67937bfdd78f7e0571da658b2bfe66515500529acb3a8bc87719e53ef98c77fa43070de838dd19c943db8eadc6a98c3a8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-lipsum.0.2.1`: A SATySFi package of dummy text
-`satysfi-lipsum-doc.0.2.1`: Document: A SATySFi package of dummy text



---
* Homepage: https://github.com/puripuri2100/SATySFi-lipsum
* Source repo: git+https://github.com/puripuri2100/SATySFi-lipsum.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-lipsum/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-lipsum-doc.0.2.1 satysfi-lipsum.0.2.1
- [x] Add to snapshot `snapshot-stable-0-0-4` :: satysfi-lipsum-doc.0.2.1 satysfi-lipsum.0.2.1
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-lipsum-doc.0.2.1 satysfi-lipsum.0.2.1
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-lipsum-doc.0.2.1 satysfi-lipsum.0.2.1