### PR TITLE
2 packages from puripuri2100/SATySFi-uline at 0.2.2

### DIFF
--- a/packages/satysfi-uline-doc/satysfi-uline-doc.0.2.2/opam
+++ b/packages/satysfi-uline-doc/satysfi-uline-doc.0.2.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document: Underline for SAtySFi"
+description: """Document: Underline for SAtySFi"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-uline"
+bug-reports: "https://github.com/puripuri2100/SATySFi-uline/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-uline.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+  "satysfi-dist"
+  "satysfi-uline" {= "%{version}%"}
+  "satysfi-lipsum" {>= "0.2.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "uline-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "uline-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-uline/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=29dd58d19c4364d4d8d3656e9f0b754d"
+    "sha512=b9dedc63a191036a7d73e34117fc6c41ce643bd684c877cd83ec91e6688eb7c04e095d4802ae6d764ca287830b8884ce2b2a0fa46ec1e61609ae3cfb8a67b29f"
+  ]
+}

--- a/packages/satysfi-uline/satysfi-uline.0.2.2/opam
+++ b/packages/satysfi-uline/satysfi-uline.0.2.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Underline for SAtySFi"
+description: """Underline for SAtySFi"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-uline"
+bug-reports: "https://github.com/puripuri2100/SATySFi-uline/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-uline.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.4"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "uline"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-uline/archive/0.2.2.tar.gz"
+  checksum: [
+    "md5=29dd58d19c4364d4d8d3656e9f0b754d"
+    "sha512=b9dedc63a191036a7d73e34117fc6c41ce643bd684c877cd83ec91e6688eb7c04e095d4802ae6d764ca287830b8884ce2b2a0fa46ec1e61609ae3cfb8a67b29f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-uline.0.2.2`: Underline for SAtySFi
-`satysfi-uline-doc.0.2.2`: Document: Underline for SAtySFi



---
* Homepage: https://github.com/puripuri2100/SATySFi-uline
* Source repo: git+https://github.com/puripuri2100/SATySFi-uline.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-uline/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-uline-doc.0.2.2 satysfi-uline.0.2.2
- [x] Add to snapshot `snapshot-stable-0-0-4` :: satysfi-uline-doc.0.2.2 satysfi-uline.0.2.2
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-uline-doc.0.2.2 satysfi-uline.0.2.2
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-uline-doc.0.2.2 satysfi-uline.0.2.2