### PR TITLE
2 packages from puripuri2100/SATySFi-num-conversion at 0.1.3

### DIFF
--- a/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.3/opam
+++ b/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document: Convert numbers to the following notation"
+description: """Document: Convert numbers to the following notation."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-num-conversion"
+bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-num-conversion" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "num-conversion-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "num-conversion-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-num-conversion/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=6fd7218b2fa7194114d2198626b9d3d3"
+    "sha512=40db3b022b840cdf2c158a38ec7fa36f1cb7a2a7c561da71089a4c97a158adcd80ca7a7ccad585ae3ad41cc8cb67631227ba8188bc8f776596bf52f8cd047d65"
+  ]
+}

--- a/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.3/opam
+++ b/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Convert numbers to the following notation"
+description: """Convert numbers to the following notation."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-num-conversion"
+bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-base" {>= "1.0.0"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "num-conversion"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-num-conversion/archive/0.1.3.tar.gz"
+  checksum: [
+    "md5=6fd7218b2fa7194114d2198626b9d3d3"
+    "sha512=40db3b022b840cdf2c158a38ec7fa36f1cb7a2a7c561da71089a4c97a158adcd80ca7a7ccad585ae3ad41cc8cb67631227ba8188bc8f776596bf52f8cd047d65"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-num-conversion.0.1.3`: Convert numbers to the following notation
-`satysfi-num-conversion-doc.0.1.3`: Document: Convert numbers to the following notation



---
* Homepage: https://github.com/puripuri2100/SATySFi-num-conversion
* Source repo: git+https://github.com/puripuri2100/SATySFi-num-conversion.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-num-conversion/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)