### PR TITLE
2 packages from puripuri2100/SATySFi-num-conversion at 0.1.4

### DIFF
--- a/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.4/opam
+++ b/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Document: Convert numbers to the following notation"
+description: """Document: Convert numbers to the following notation."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-num-conversion"
+bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-num-conversion" {= "%{version}%"}
+  "satysfi-assert-eq"
+  "satysfi-debug-show-value"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "num-conversion-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "num-conversion-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-num-conversion/archive/0.1.4.tar.gz"
+  checksum: [
+    "md5=27268c44b26417064fbd7815b3e04ed9"
+    "sha512=bf69ed3984a0e9007aeff57eb5736e44d48fcdcee48755cfe2c88fe7329857bca4cf4343f4df0ce4d0e7905ce2e117cfa8a83f07320f287271f80fcd5fb0abc9"
+  ]
+}

--- a/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.4/opam
+++ b/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Convert numbers to the following notation"
+description: """Convert numbers to the following notation."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-num-conversion"
+bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-base" {>= "1.0.0"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "num-conversion"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-num-conversion/archive/0.1.4.tar.gz"
+  checksum: [
+    "md5=27268c44b26417064fbd7815b3e04ed9"
+    "sha512=bf69ed3984a0e9007aeff57eb5736e44d48fcdcee48755cfe2c88fe7329857bca4cf4343f4df0ce4d0e7905ce2e117cfa8a83f07320f287271f80fcd5fb0abc9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-num-conversion.0.1.4`: Convert numbers to the following notation
-`satysfi-num-conversion-doc.0.1.4`: Document: Convert numbers to the following notation



---
* Homepage: https://github.com/puripuri2100/SATySFi-num-conversion
* Source repo: git+https://github.com/puripuri2100/SATySFi-num-conversion.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-num-conversion/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-num-conversion-doc.0.1.4 satysfi-num-conversion.0.1.4
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-num-conversion-doc.0.1.4 satysfi-num-conversion.0.1.4
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-num-conversion-doc.0.1.4 satysfi-num-conversion.0.1.4