### PR TITLE
2 packages from monaqa/satysfi-easytable at 1.1.1

### DIFF
--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-easytable" {= "%{version}%"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8a2b2e6c70b012e5c26c5a2e5401f25d"
+    "sha512=d7313d3c4eea56c15d2c793e41ddf8c91a4453de100b26527008835d3ca9454ee72846ca6f2c2978ba6faf51c7199045697a84b49906b5a598eacac90fbe9d81"
+  ]
+}

--- a/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.1.tar.gz"
+  checksum: [
+    "md5=8a2b2e6c70b012e5c26c5a2e5401f25d"
+    "sha512=d7313d3c4eea56c15d2c793e41ddf8c91a4453de100b26527008835d3ca9454ee72846ca6f2c2978ba6faf51c7199045697a84b49906b5a598eacac90fbe9d81"
+  ]
+}


### PR DESCRIPTION
This PR is created manually because `opam publish` command failed somehow.

---

A SATySFi package to build simple tables

This pull-request concerns:
-`satysfi-easytable.1.1.1`
-`satysfi-easytable-doc.1.1.1`



---
* Homepage: https://github.com/monaqa/satysfi-easytable
* Source repo: git+https://github.com/monaqa/satysfi-easytable.git
* Bug tracker: https://github.com/monaqa/satysfi-easytable/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [ ] Add to snapshot `snapshot-develop` :: satysfi-easytable-doc.1.1.1 satysfi-easytable.1.1.1
- ~~~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)~~ (Inconsistent)
- [ ] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-easytable-doc.1.1.1 satysfi-easytable.1.1.1
- [ ] [ ] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-easytable-doc.1.1.1 satysfi-easytable.1.1.1 :: satysfi-easytable-doc.1.1.1 satysfi-easytable.1.1.1