### PR TITLE
Fix dependency of  satysfi-debug-show-value

### DIFF
--- a/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
+++ b/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
@@ -11,6 +11,7 @@ dev-repo: "git+https://github.com/puripuri2100/SATySFi-debug-show-value.git"
 
 depends: [
   "satysfi" {>= "0.0.3" & < "0.0.7"}
+  "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]
 install: [


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- Add to snapshot `snapshot-stable-0-0-4`
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`