### PR TITLE
Add missing dependency on satysfi-base

### DIFF
--- a/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
@@ -13,6 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
+  "satysfi-base"
 ]
 install: [
   ["satyrographos" "opam" "install"


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- Add to snapshot `snapshot-stable-0-0-4`
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`