### PR TITLE
2 packages from puripuri2100/SATySFi-md2latex at 0.0.3

### DIFF
--- a/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
+++ b/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of md2latex Package"
+description: """
+Document of md2latex Package.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-md2latex" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "md2latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "md2latex-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-md2latex/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=3923f46f547d81f82f8e5a70c17ab2d1"
+    "sha512=c1390d51922387f8b1e830c84095fe55e0fcce2de4dd573ac8766778e4e8b0f29427fefc9bf7fc021b70117443102b7dab77de95c22539c3663cba84b906b9e1"
+  ]
+}

--- a/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
+++ b/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Convert Markdown to LaTeX with SATySFi"
+description: """
+Convert Markdown to LaTeX with SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-make-latex" {>= "0.2.0" & < "0.3.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "md2latex"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-md2latex/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=3923f46f547d81f82f8e5a70c17ab2d1"
+    "sha512=c1390d51922387f8b1e830c84095fe55e0fcce2de4dd573ac8766778e4e8b0f29427fefc9bf7fc021b70117443102b7dab77de95c22539c3663cba84b906b9e1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-md2latex.0.0.3`: Convert Markdown to LaTeX with SATySFi
-`satysfi-md2latex-doc.0.0.3`: Document of md2latex Package



---
* Homepage: https://github.com/puripuri2100/SATySFi-md2latex
* Source repo: git+https://github.com/puripuri2100/SATySFi-md2latex.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-md2latex/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-md2latex-doc.0.0.3 satysfi-md2latex.0.0.3
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-md2latex-doc.0.0.3 satysfi-md2latex.0.0.3
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-md2latex-doc.0.0.3 satysfi-md2latex.0.0.3