### PR TITLE
2 packages from puripuri2100/SATySFi-image at 0.1.0

### DIFF
--- a/packages/satysfi-image-doc/satysfi-image-doc.0.1.0/opam
+++ b/packages/satysfi-image-doc/satysfi-image-doc.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Document of an insert image with SATySFi"
+description: """
+Document of an insert image with SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/puripuri2100/SATySFi-image"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-image.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-image/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-image" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "image-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "image-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-image/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=74074c659938b42a91c94651a671a1ec"
+    "sha512=ee5735999d27946f3ee1cce8d64574b70aa7e16e720d831c55659668a4674256307d6f0c1598d69c14bbcbe3e0f4669085d546a3671d4a8e24a0d14e94f0b0f1"
+  ]
+}

--- a/packages/satysfi-image/satysfi-image.0.1.0/opam
+++ b/packages/satysfi-image/satysfi-image.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Insert image with SATySFi"
+description: """
+Insert image with SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-image"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-image.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-image/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "image"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "image"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-image/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=74074c659938b42a91c94651a671a1ec"
+    "sha512=ee5735999d27946f3ee1cce8d64574b70aa7e16e720d831c55659668a4674256307d6f0c1598d69c14bbcbe3e0f4669085d546a3671d4a8e24a0d14e94f0b0f1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-image.0.1.0`: Insert image with SATySFi
-`satysfi-image-doc.0.1.0`: Document of an insert image with SATySFi



---
* Homepage: https://github.com/puripuri2100/SATySFi-image
* Source repo: git+https://github.com/puripuri2100/SATySFi-image.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-image/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-image-doc.0.1.0 satysfi-image.0.1.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-image-doc.0.1.0 satysfi-image.0.1.0