### PR TITLE
2 packages from puripuri2100/SATySFi-json at 1.0.1

### DIFF
--- a/packages/satysfi-json-doc/satysfi-json-doc.1.0.1/opam
+++ b/packages/satysfi-json-doc/satysfi-json-doc.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Document of JSON parser for SATySFi"
+description: """
+Document of JSON parser for SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/puripuri2100/SATySFi-json"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-json.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-json/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-json" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-base"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "json-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "json-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-json/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=a7b0814e38596ab8216bd4f3c27607ec"
+    "sha512=37ad9a6bbaa81cea1e0a79a5114a3f60b4f5c5e6bd3a38784fd2bfd86b4c71616f3a21144e4ae3c10ea7817c9e994da66d1a8c6ca3403de4d5467c00a677ec2e"
+  ]
+}

--- a/packages/satysfi-json/satysfi-json.1.0.1/opam
+++ b/packages/satysfi-json/satysfi-json.1.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "JSON parser for SATySFi"
+description: """
+JSON parser for SATySFi.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/SATySFi-json"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-json.git"
+bug-reports: "https://github.com/puripuri2100/SATySFi-json/issues"
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "json"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "json"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/SATySFi-json/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=a7b0814e38596ab8216bd4f3c27607ec"
+    "sha512=37ad9a6bbaa81cea1e0a79a5114a3f60b4f5c5e6bd3a38784fd2bfd86b4c71616f3a21144e4ae3c10ea7817c9e994da66d1a8c6ca3403de4d5467c00a677ec2e"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-json.1.0.1`: JSON parser for SATySFi
-`satysfi-json-doc.1.0.1`: Document of JSON parser for SATySFi



---
* Homepage: https://github.com/puripuri2100/SATySFi-json
* Source repo: git+https://github.com/puripuri2100/SATySFi-json.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-json/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-json-doc.1.0.1 satysfi-json.1.0.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-json-doc.1.0.1 satysfi-json.1.0.1
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-json-doc.1.0.1 satysfi-json.1.0.1