### PR TITLE
2 packages from monaqa/slydifi at 0.3.0

### DIFF
--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-slydifi" {= "%{version}%"}
+  "satysfi-easytable" {>= "1.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-slydifi-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-slydifi-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.3.0.tar.gz"
+  checksum: [
+    "md5=c81145db8a948464cd6d7583345949e6"
+    "sha512=c7bfd7156652e5d5f32864d55842d967ad175d2647be75ead71ff2d1c3f6a698a141e02ec606659cb87f4731ffb7ab6624fac145e27eea1666fb42b59a764c5d"
+  ]
+}

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-figbox" {>= "0.1.1"}
+  "satysfi-base" {>= "1.0.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-slydifi"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.3.0.tar.gz"
+  checksum: [
+    "md5=c81145db8a948464cd6d7583345949e6"
+    "sha512=c7bfd7156652e5d5f32864d55842d967ad175d2647be75ead71ff2d1c3f6a698a141e02ec606659cb87f4731ffb7ab6624fac145e27eea1666fb42b59a764c5d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `satysfi-class-slydifi.0.3.0`: A SATySFi document class for creating presentations slides
- `satysfi-class-slydifi-doc.0.3.0`: A SATySFi document class for creating presentations slides

---
* Homepage: https://github.com/monaqa/slydifi
* Source repo: git+https://github.com/monaqa/slydifi.git
* Bug tracker: https://github.com/monaqa/slydifi/issues

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)