### PR TITLE
2 packages from puripuri2100/SATySFi-fonts-han-sans-jp at 2.003R

### DIFF
--- a/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for han sans JP fonts"
+description: """
+Document package for satysfi-fonts-han-sans-jp
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git"
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-fonts-han-sans-jp" { = "%{version}%" }
+  "satysfi-lipsum"
+]
+build: [
+  ["satyrographos" "opam" "build"
+    "--name" "fonts-han-sans-jp-doc"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "--name" "fonts-han-sans-jp-doc"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/archive/2.003R.tar.gz"
+  checksum: [
+    "md5=6c02f94b1dc152d438b33c9ab4909005"
+    "sha512=f1c2e0c64b0b6cd39f92ed9dbf7182684ea42cc4704672fe081e923019e99ecd8154862621729b5352bdc786bd4618b6aa3218988d8627041f5e93e312253d47"
+  ]
+}

--- a/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git"
 depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-han-sans-jp" { = "%{version}%" }
   "satysfi-lipsum"

--- a/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
@@ -20,7 +20,7 @@ extra-source "SourceHanSansJP.zip" {
 }
 depends: [
   "satysfi" {>= "0.0.4" & < "0.0.7"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [
   ["unzip" "-j" "-d" "SourceHanSansJP" "-o" "SourceHanSansJP.zip" "*.otf"]

--- a/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for han sans JP fonts（源ノ角ゴシック）"
+description: """
+SATySFi font package for han sans JP fonts（源ノ角ゴシック）.
+
+This package installs fonts from https://github.com/adobe-fonts/source-han-sans.
+"""
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "OFL-1.1"
+homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp"
+bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues"
+dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git"
+extra-source "SourceHanSansJP.zip" {
+  archive: "https://github.com/puripuri2100/source-han-sans/releases/download/2.003R/SourceHanSansJP.zip"
+  checksum: [
+    "sha256=d38a4df5050f725680aa3b3e27b9b6129c7deb395b6d6a9098e8b49f71a8d982"
+    "sha512=eb09ee9dfda89b1531546196933d14ed5e6f8c3b5ee8c60b1d12618cf3fdeffed1c29784c9a56a12fb725cbc5b5a24e99102571db4d09162f61fbf1ec7f62e4b"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [
+  ["unzip" "-j" "-d" "SourceHanSansJP" "-o" "SourceHanSansJP.zip" "*.otf"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+    "--name" "fonts-han-sans-jp"
+    "--prefix" "%{prefix}%"
+    "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/archive/2.003R.tar.gz"
+  checksum: [
+    "md5=6c02f94b1dc152d438b33c9ab4909005"
+    "sha512=f1c2e0c64b0b6cd39f92ed9dbf7182684ea42cc4704672fe081e923019e99ecd8154862621729b5352bdc786bd4618b6aa3218988d8627041f5e93e312253d47"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-han-sans-jp.2.003R`: SATySFi Font Package for han sans JP fonts（源ノ角ゴシック）
-`satysfi-fonts-han-sans-jp-doc.2.003R`: Document of SATySFi Font Package for han sans JP fonts



---
* Homepage: https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp
* Source repo: git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git
* Bug tracker: https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues

---
:camel: Pull-request generated by opam-publish v2.0.2
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-fonts-han-sans-jp-doc.2.003R satysfi-fonts-han-sans-jp.2.003R
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-fonts-han-sans-jp-doc.2.003R satysfi-fonts-han-sans-jp.2.003R
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-fonts-han-sans-jp-doc.2.003R satysfi-fonts-han-sans-jp.2.003R