### PR TITLE
Build against OCaml 4.12.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
         ocaml-version:
 #         - 4.10.1
           - 4.11.1
+          - 4.12.0
         snapshot:
           - stable-0-0-6
           - stable-0-0-5


### PR DESCRIPTION
This PR adds CI against OCaml 4.12.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)