### PR TITLE
Package satysfi-class-jlreq.0.0.2

### DIFF
--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+synopsis: "A document class for SATySFi"
+authors: "Noriyuki Abe"
+maintainer: "Noriyuki Abe"
+homepage: "https://github.com/abenori/satysfi-class-jlreq/"
+bug-reports: "https://github.com/abenori/satysfi-class-jlreq/issues"
+dev-repo: "git+https://github.com/abenori/satysfi-class-jlreq.git"
+license: "BSD-2-Clause-FreeBSD"
+depends: [
+  "satysfi" {>= "0.0.6"}
+  "satysfi-base" {>= "0.0.2"}
+  "satysfi-fss" {>= "0.0.2"}
+  "satyrographos" {>= "0.0.2"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-jlreq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]

--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
@@ -18,3 +18,11 @@ install: [
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
+url {
+  src:
+    "https://github.com/abenori/satysfi-class-jlreq/archive/0.0.2.tar.gz"
+  checksum: [
+    "md5=5b9b9504df1e73a3924f5192e4b0fe96"
+    "sha512=700aaae58aa0820a5e21637b570356cfafd78222d009e9ba2630b4db76c4b9fab40af99a97b5c6977a350d59e8ac8505f131bd5628b8f8010adad5f081708aeb"
+  ]
+}


### PR DESCRIPTION
### `satysfi-class-jlreq.0.0.2`
A document class for SATySFi



---
* Homepage: https://github.com/abenori/satysfi-class-jlreq/
* Source repo: git+https://github.com/abenori/satysfi-class-jlreq.git
* Bug tracker: https://github.com/abenori/satysfi-class-jlreq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-class-jlreq.0.0.2
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-class-jlreq.0.0.2