### PR TITLE
2 packages from monaqa/satysfi-figbox at 0.1.2

### DIFF
--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Document for satysfi-figbox package"
+description: """
+A SATySFi package that creates charts and places them in inappropriate positions in your document
+"""
+maintainer: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+authors: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/monaqa/satysfi-figbox"
+dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
+bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-figbox" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-base"
+  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "figbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "figbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-figbox/archive/v0.1.1.tar.gz"
+  checksum: [
+    "md5=ec6e37d17917b50bf6026af4bfa9fe85"
+    "sha512=1a7df024438f5a1c76ea39b825368017011113133815a328a7724675b04e4922b2084de444b955086ddac36bd10ea7ea82167a505c5dcfa0ec6713d2c444e650"
+  ]
+}

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.2/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package for creating charts and placing them in inappropriate positions"
+description: """
+A SATySFi package that creates charts and places them in inappropriate positions in your document
+"""
+maintainer: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+authors: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/monaqa/satysfi-figbox"
+dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
+bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "figbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-figbox/archive/v0.1.1.tar.gz"
+  checksum: [
+    "md5=ec6e37d17917b50bf6026af4bfa9fe85"
+    "sha512=1a7df024438f5a1c76ea39b825368017011113133815a328a7724675b04e4922b2084de444b955086ddac36bd10ea7ea82167a505c5dcfa0ec6713d2c444e650"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-figbox.0.1.2`: A SATySFi package for creating charts and placing them in inappropriate positions
-`satysfi-figbox-doc.0.1.2`: Document for satysfi-figbox package



---
* Homepage: https://github.com/monaqa/satysfi-figbox
* Source repo: git+https://github.com/monaqa/satysfi-figbox.git
* Bug tracker: https://github.com/monaqa/satysfi-figbox/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-figbox-doc.0.1.2 satysfi-figbox.0.1.2
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-figbox-doc.0.1.2 satysfi-figbox.0.1.2