### PR TITLE
Apply CC0-1.0+ license to the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ To submit a PR to `devel` branch, specify `-b` option.
 opam publish --repo=na4zagin3/satyrographos-repo -b develop
 ```
 
+## License
+
+All the metadata contained in this repository are licensed under the [CC0 1.0 Universal license](https://creativecommons.org/publicdomain/zero/1.0/) or any later version (i.e., `CC0-1.0+` license in [SPDX License Identifier](https://spdx.org/licenses/)).
+
 ### Reference
 
 * ["Repository format"](https://opam.ocaml.org/doc/Manual.html#Repository-format)


### PR DESCRIPTION
Since we got approvals from the contributors, we can apply CC0-1.0+ license to the repository.

Close https://github.com/na4zagin3/satyrographos-repo/issues/334
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)