### PR TITLE
Package satysfi-cancel.0.0.1

### DIFF
--- a/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
+++ b/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The cancel package"
+description: """
+The SATySFi equivalent of the LateX's cancel package.
+"""
+maintainer: "Yu Shimura <mail@yuhr.org>"
+authors: "Yu Shimura <mail@yuhr.org>"
+license: "CC0-1.0"
+homepage: "https://github.com/yuhr/satysfi-cancel"
+bug-reports: "https://github.com/yuhr/satysfi-cancel/issues"
+dev-repo: "git+https://github.com/yuhr/satysfi-cancel.git"
+depends: [
+  "satysfi"
+  "satyrographos"
+  "satysfi-dist"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "cancel"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/yuhr/satysfi-cancel/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=0d8b043ee3c68c9355c0f44a6a7b253f"
+    "sha512=7cd50e0d4ac7c7cb7726770ad0b0c65e6a2e91d9c2c52710075ffe87de8273ba7598b46cfd6aef731927c3cf6467c803edfa4595fb28f3e9ed2f6456abb7fcb7"
+  ]
+}


### PR DESCRIPTION
### `satysfi-cancel.0.0.1`
The cancel package
The SATySFi equivalent of the LateX's cancel package.



---
* Homepage: https://github.com/yuhr/satysfi-cancel
* Source repo: git+https://github.com/yuhr/satysfi-cancel.git
* Bug tracker: https://github.com/yuhr/satysfi-cancel/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-cancel.0.0.1
- [x] Add to snapshot `snapshot-stable-0-0-4` :: satysfi-cancel.0.0.1
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-cancel.0.0.1
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-cancel.0.0.1