### PR TITLE
2 packages from monaqa/satysfi-figbox at 0.1.3

### DIFF
--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Document for satysfi-figbox package"
+description: """
+A SATySFi package that creates charts and places them in inappropriate positions in your document
+"""
+maintainer: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+authors: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/monaqa/satysfi-figbox"
+dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
+bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-figbox" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-base"
+  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-enumitem" {>= "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "figbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "figbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-figbox/archive/v0.1.3.tar.gz"
+  checksum: [
+    "md5=789cdeb2bac391aed088ca56c7d9e266"
+    "sha512=97efaedc46391fbb47ba15ce70169f8de20fbdd48430c727fbcb2c6e4388ace1ab20ca6c7c8ecb7e6b25e9e9df5aea24cfc02568dd652095b680b1409c9fd72c"
+  ]
+}

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.3/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package for creating charts and placing them in inappropriate positions"
+description: """
+A SATySFi package that creates charts and places them in inappropriate positions in your document
+"""
+maintainer: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+authors: "Mogami Shinichi <mogassy@yahoo.co.jp>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/monaqa/satysfi-figbox"
+dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
+bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "figbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-figbox/archive/v0.1.3.tar.gz"
+  checksum: [
+    "md5=789cdeb2bac391aed088ca56c7d9e266"
+    "sha512=97efaedc46391fbb47ba15ce70169f8de20fbdd48430c727fbcb2c6e4388ace1ab20ca6c7c8ecb7e6b25e9e9df5aea24cfc02568dd652095b680b1409c9fd72c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-figbox.0.1.3`: A SATySFi package for creating charts and placing them in inappropriate positions
-`satysfi-figbox-doc.0.1.3`: Document for satysfi-figbox package



---
* Homepage: https://github.com/monaqa/satysfi-figbox
* Source repo: git+https://github.com/monaqa/satysfi-figbox.git
* Bug tracker: https://github.com/monaqa/satysfi-figbox/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-figbox-doc.0.1.3 satysfi-figbox.0.1.3
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-figbox-doc.0.1.3 satysfi-figbox.0.1.3