### PR TITLE
2 packages from monaqa/slydifi at 0.3.1

### DIFF
--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.1/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-slydifi" {= "%{version}%"}
+  "satysfi-easytable" {>= "1.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-slydifi-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-slydifi-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=7f528dde302a56d6edc6ae4673db00e5"
+    "sha512=8795acb6de3e556be8ed33b25bf59c10f271fc007f514cc21f58a54878645f8de5aef9e99662717938d56537025834e2659f2d93ea73b8b0cd8de576303380c2"
+  ]
+}

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.1/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-figbox" {>= "0.1.3"}
+  "satysfi-base" {>= "1.0.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-slydifi"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=7f528dde302a56d6edc6ae4673db00e5"
+    "sha512=8795acb6de3e556be8ed33b25bf59c10f271fc007f514cc21f58a54878645f8de5aef9e99662717938d56537025834e2659f2d93ea73b8b0cd8de576303380c2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `satysfi-class-slydifi.0.3.1`: A SATySFi document class for creating presentations slides
- `satysfi-class-slydifi-doc.0.3.1`: A SATySFi document class for creating presentations slides

---
* Homepage: https://github.com/monaqa/slydifi
* Source repo: git+https://github.com/monaqa/slydifi.git
* Bug tracker: https://github.com/monaqa/slydifi/issues
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [ ] Add to snapshot `snapshot-develop` :: satysfi-class-slydifi-doc.0.3.1 satysfi-class-slydifi.0.3.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [ ] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-class-slydifi-doc.0.3.1 satysfi-class-slydifi.0.3.1