### PR TITLE
2 packages from monaqa/satysfi-railway at 0.1.0

### DIFF
--- a/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
+++ b/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Drawing library for SATySFi"
+description: """
+Document for satysfi-railway, drawing library for SATySFi.
+"""
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/monaqa/satysfi-railway"
+dev-repo: "git+https://github.com/monaqa/satysfi-railway.git"
+bug-reports: "https://github.com/monaqa/satysfi-railway/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-railway" {= "%{version}%"}
+  "satysfi-dist"
+  "satysfi-base"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "railway-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "railway-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-railway/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=44ef0a9c9f012d407d27b6bbff657099"
+    "sha512=747dac385bf2105cb86adace431f734cee898692c8eaa0ca57776a968fe107b3e0503c29216eedf7e68aadbd55f12d1017b37313c3b56d004c5d549f440f829e"
+  ]
+}

--- a/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
+++ b/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
@@ -5,7 +5,7 @@ Document for satysfi-railway, drawing library for SATySFi.
 """
 maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
 authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
-license: "MIT" # Choose what you want
+license: "MIT"
 homepage: "https://github.com/monaqa/satysfi-railway"
 dev-repo: "git+https://github.com/monaqa/satysfi-railway.git"
 bug-reports: "https://github.com/monaqa/satysfi-railway/issues"
@@ -16,8 +16,7 @@ depends: [
 
   # You may want to include the corresponding library
   "satysfi-railway" {= "%{version}%"}
-  "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-railway/satysfi-railway.0.1.0/opam
+++ b/packages/satysfi-railway/satysfi-railway.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Drawing library for SATySFi"
+description: """
+Drawing library for SATySFi.
+"""
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-railway"
+dev-repo: "git+https://github.com/monaqa/satysfi-railway.git"
+bug-reports: "https://github.com/monaqa/satysfi-railway/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "railway"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-railway/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=44ef0a9c9f012d407d27b6bbff657099"
+    "sha512=747dac385bf2105cb86adace431f734cee898692c8eaa0ca57776a968fe107b3e0503c29216eedf7e68aadbd55f12d1017b37313c3b56d004c5d549f440f829e"
+  ]
+}

--- a/packages/satysfi-railway/satysfi-railway.0.1.0/opam
+++ b/packages/satysfi-railway/satysfi-railway.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
 ]
 install: [
   ["satyrographos" "opam" "install"


### PR DESCRIPTION
This pull-request concerns:
- `satysfi-railway.0.1.0`: Drawing library for SATySFi
- `satysfi-railway-doc.0.1.0`: Drawing library for SATySFi

---
* Homepage: https://github.com/monaqa/satysfi-railway
* Source repo: git+https://github.com/monaqa/satysfi-railway.git
* Bug tracker: https://github.com/monaqa/satysfi-railway/issues
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-railway-doc.0.1.0 satysfi-railway.0.1.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-railway-doc.0.1.0 satysfi-railway.0.1.0