### PR TITLE
Remove unneeded dependency on depext

### DIFF
--- a/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
@@ -64,7 +64,6 @@ depends: [
   "camlpdf" {= "2.2.1+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.02.10/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.02.10/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.02.13/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.02.13/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.03.10/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.07.14/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.07.14/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2019.11.16/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.3/opam
+++ b/packages/satysfi/satysfi.0.0.3/opam
@@ -64,7 +64,6 @@ depends: [
   "camlpdf" {= "2.2.1+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.02.09/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.02.09/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.02.16/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.02.16/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.02.22/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.02.22/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.04.05/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.04.05/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.04.25/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.04.25/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4+dev2020.06.07/opam
+++ b/packages/satysfi/satysfi.0.0.4+dev2020.06.07/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.4/opam
+++ b/packages/satysfi/satysfi.0.0.4/opam
@@ -26,7 +26,6 @@ depends: [
   "camlpdf" {= "2.2.2+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi/satysfi.0.0.5+dev2020.09.05/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.5-59-g32f2525/opam
+++ b/packages/satysfi/satysfi.0.0.5-59-g32f2525/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.5-83-g360d941/opam
+++ b/packages/satysfi/satysfi.0.0.5-83-g360d941/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.5/opam
+++ b/packages/satysfi/satysfi.0.0.5/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.6-25-g4083234/opam
+++ b/packages/satysfi/satysfi.0.0.6-25-g4083234/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.6-32-g9dbd61d/opam
+++ b/packages/satysfi/satysfi.0.0.6-32-g9dbd61d/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.6-43-ga86452bc/opam
+++ b/packages/satysfi/satysfi.0.0.6-43-ga86452bc/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.6-53-g2867e4d9/opam
+++ b/packages/satysfi/satysfi.0.0.6-53-g2867e4d9/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}

--- a/packages/satysfi/satysfi.0.0.6/opam
+++ b/packages/satysfi/satysfi.0.0.6/opam
@@ -24,7 +24,6 @@ depends: [
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
-  "depext"
   "dune" {build}
   "menhir"
   "ocamlfind" {build}


### PR DESCRIPTION
SATySFi declares dependency on depext while it in fact does not.

This PR addresses https://github.com/gfngfn/SATySFi/issues/287

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)