### PR TITLE
Use opam-repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           dune-cache: true
           cache-prefix: "snapshot-${{ matrix.snapshot }}"
 
-          ocaml-repositories: |
+          opam-repositories: |
             satysfi-external: https://github.com/gfngfn/satysfi-external-repo.git
             satyrographos-local: .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,18 @@ jobs:
 
       - name: Output Run ID/Number
         run: echo ${{ github.run_id }} ${{ github.run_number }}
+        
+      - name: Determine the default OPAM Repo
+        id: determine-default-opam-repo
+        # See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#runner-context
+        # and https://github.com/ocaml/setup-ocaml/blob/4ac56b0fd440c3eef30fd1e34c96e0c740a807da/src/constants.ts#L45
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ] ; then
+            DEFAULT_OPAM_REPO="https://github.com/fdopen/opam-repository-mingw.git#opam2"
+          else
+            DEFAULT_OPAM_REPO="https://github.com/ocaml/opam-repository.git"
+          fi
+          echo "::set-output name=opam-repo-default::$(echo "$DEFAULT_OPAM_REPO")"
 
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
@@ -55,6 +67,7 @@ jobs:
           opam-repositories: |
             satysfi-external: https://github.com/gfngfn/satysfi-external-repo.git
             satyrographos-local: git+file://${{ github.workspace }}
+            default: ${{ steps.determine-default-opam-repo.outputs.opam-repo-default }}
 
       - name: Check validity of the snapshot OPAM files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,9 @@ jobs:
           dune-cache: true
           cache-prefix: "snapshot-${{ matrix.snapshot }}"
 
+          opam-depext: false
+          opam-pin: false
+
           opam-repositories: |
             satysfi-external: https://github.com/gfngfn/satysfi-external-repo.git
             satyrographos-local: git+file://${{ github.workspace }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
 
           opam-repositories: |
             satysfi-external: https://github.com/gfngfn/satysfi-external-repo.git
-            satyrographos-local: .
+            satyrographos-local: git+file://${{ github.workspace }}
 
       - name: Check validity of the snapshot OPAM files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
           - stable-0-0-6
           - stable-0-0-5
           - develop
-        cache-opam-directory:
-          - false
         include:
           - os: 'ubuntu-latest'
             ocaml-version: '4.06.1'
@@ -44,27 +42,8 @@ jobs:
           git remote set-branches --add origin master
           git fetch --depth 50 origin master
 
-      - name: Cache OPAM directory (Non Windows)
-        uses: actions/cache@v2
-        if: runner.os != 'Windows' && runner.cache-opam-directory
-        with:
-          path: "~/.opam"
-          key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ matrix.snapshot }}
-
-      - name: Cache OPAM directory (Windows)
-        uses: actions/cache@v2
-        if: runner.os == 'Windows' && runner.cache-opam-directory
-        with:
-          path: "C:\\cygwin\\home\\runneradmin\\.opam"
-          key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ matrix.snapshot }}
-
       - name: Output Run ID/Number
         run: echo ${{ github.run_id }} ${{ github.run_number }}
-
-      - name: Remove Cache (workaround)
-        if: endsWith(github.run_number, '2') && runner.cache-opam-directory
-        run: |
-          rm -rf "$HOME/.opam"
 
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
@@ -73,9 +52,9 @@ jobs:
           dune-cache: true
           cache-prefix: "snapshot-${{ matrix.snapshot }}"
 
-          # Workaround https://github.com/ocaml/setup-ocaml/issues/80
-          opam-depext: false
-          opam-pin: false
+          ocaml-repositories: |
+            satysfi-external: https://github.com/gfngfn/satysfi-external-repo.git
+            satyrographos-local: .
 
       - name: Check validity of the snapshot OPAM files
         run: |
@@ -85,28 +64,13 @@ jobs:
         run: |
           find packages -iname opam -exec opam lint --strict '{}' '+'
 
-      - name: Clean up OPAM caches
-        run: |
-          opam clean --logs --repo-cache --switch-cleanup
-        
-      - name: Setup OPAM repositories
-        run: |
-          opam repository remove --all satysfi-external satyrographos-local || true
-          opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
-          # opam repository add satyrographos-local "file://$PWD"
-          opam repository add satyrographos-local .
-          opam update --debug
-
       - name: Update packages
         run: |
           show_cudf_files() {
             for f in update-packages-*.cudf ; do echo "$f" ; cat "$f" ; done
           }
-          opam pin add --no-action satysfi "$(opam show satysfi -f version)" || true
-          opam pin add --no-action satyrographos "$(opam show satyrographos -f version)" || true
           opam upgrade --yes --debug --cudf=update-packages || ( show_cudf_files ; false )
           show_cudf_files
-          opam pin remove satysfi satyrographos
 
       - name: Install the snapshot
         run: |
@@ -166,7 +130,4 @@ jobs:
         with:
           name: "pr-snapshot-${{ matrix.snapshot }}"
           path: pr/
-            
-      - name: Clean up logs and temporary files
-        run: |
-          opam clean --switch-cleanup --logs
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,14 +80,6 @@ jobs:
         run: |
           find packages -iname opam -exec opam lint --strict '{}' '+'
 
-      - name: Update packages
-        run: |
-          show_cudf_files() {
-            for f in update-packages-*.cudf ; do echo "$f" ; cat "$f" ; done
-          }
-          opam upgrade --yes --debug --cudf=update-packages || ( show_cudf_files ; false )
-          show_cudf_files
-
       - name: Install the snapshot
         run: |
           opam pin add "${SNAPSHOT}.dev" . --no-action


### PR DESCRIPTION
Use opam-repositories for setup-ocaml and cleaned up useless steps
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)