### PR TITLE
2 packages from puripuri2100/satysfi-code-printer at 1.0.0

### DIFF
--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-code-printer" {= "%{version}%"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.7" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-code-printer" {= "%{version}%"}
   "satysfi-dist"

--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Document of satysfi-code-printer"
+description: """
+Document of satysfi-code-printer.
+satysfi-code-printer: https://github.com/puripuri2100/satysfi-code-printer
+"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/satysfi-code-printer"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
+
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-code-printer" {= "%{version}%"}
+  "satysfi-dist"
+  "satysfi-base"
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "code-printer-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-code-printer/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=e3e419474a84c37eb8d53dc32cf22d33"
+    "sha512=442c2bd248347464ffaac8dec692badbd5fb18465fb1e34f7882605070912e43f542f9bda448a765a56aae0a77b9ee49a7289427c5c5d73443cdc0852ce62512"
+  ]
+}

--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.0.0/opam
@@ -19,6 +19,12 @@ depends: [
   "satysfi-dist"
   "satysfi-base"
 ]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "code-printer-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
    "--name" "code-printer-doc"

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Typeset source code with SATySFi"
+description: """
+Typeset source code with SATySFi.
+"""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/puripuri2100/satysfi-code-printer"
+dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
+bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
+
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-dist"
+  "satysfi-base"
+  "satysfi-fonts-dejavu" {>= "2.37"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "code-printer"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/puripuri2100/satysfi-code-printer/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=e3e419474a84c37eb8d53dc32cf22d33"
+    "sha512=442c2bd248347464ffaac8dec692badbd5fb18465fb1e34f7882605070912e43f542f9bda448a765a56aae0a77b9ee49a7289427c5c5d73443cdc0852ce62512"
+  ]
+}

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.7" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-base" { >= "1.4.0" & < "2.0.0" }

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "satysfi" { >= "0.0.6" & < "0.0.7" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
   "satysfi-fonts-dejavu" {>= "2.37"}
 ]
 build: [

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.0.0/opam
@@ -18,6 +18,12 @@ depends: [
   "satysfi-base"
   "satysfi-fonts-dejavu" {>= "2.37"}
 ]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "code-printer"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
    "--name" "code-printer"


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-code-printer-doc.1.0.0 satysfi-code-printer.1.0.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)