### PR TITLE
Package satysfi-class-jlreq.0.0.3

### DIFF
--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A document class for SATySFi"
+authors: "Noriyuki Abe"
+maintainer: "Noriyuki Abe"
+homepage: "https://github.com/abenori/satysfi-class-jlreq/"
+bug-reports: "https://github.com/abenori/satysfi-class-jlreq/issues"
+dev-repo: "git+https://github.com/abenori/satysfi-class-jlreq.git"
+license: "BSD-2-Clause-FreeBSD"
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satysfi-base" {>= "1.3.0" & < "1.5.0"}
+  "satysfi-fss" {>= "0.0.2" & < "0.3.0"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3.0"}
+  "satysfi-pagenumber" {>="1.0.0" & < "2.0.0"}
+  "satysfi-pagestyle" {>="1.0.0" & < "2.0.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-jlreq"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-class-jlreq/archive/0.0.3.tar.gz"
+  checksum: [
+    "md5=e24c07ebace939afe053f139aaf50a60"
+    "sha512=4646298f6efe7296091b4a1c8b43c8747fed5d87692a374a14fe5e7b29d78135c99361bf308b111784d99f7e2fbb06ec38eb50e68e45197be0a92ce407d03ebd"
+  ]
+}


### PR DESCRIPTION
### `satysfi-class-jlreq.0.0.3`
A document class for SATySFi



---
* Homepage: https://github.com/abenori/satysfi-class-jlreq/
* Source repo: git+https://github.com/abenori/satysfi-class-jlreq.git
* Bug tracker: https://github.com/abenori/satysfi-class-jlreq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-class-jlreq.0.0.3
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-class-jlreq.0.0.3