### PR TITLE
 Fix version constraints of satysfi-class-slydifi

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -39,7 +39,7 @@ if true ; then
                     SKIP_SATYSFI_MISMATCH=1
             esac
 
-            if ! opam install --json=opam-output.json --dry-run --unlock-base "${PACKAGES_AND_OPTIONS[@]}"
+            if ! opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
             then
                 echo "Assuming dependency does not meet. Skipping"
                 echo "$PACKAGE: skipped: dependency" >> "$SUCCEEDED_PACKAGES"

--- a/ci.sh
+++ b/ci.sh
@@ -15,15 +15,15 @@ if true ; then
 
     eval $(opam config env)
 
-    sed -i.bak -e '/^# Package List$/,/^# Package List End$/d' "$SNAPSHOT".opam
-    opam update
-
     git remote -v
     git branch -va
 
     export OPAMYES=1
     git diff --name-status origin/master... -- packages/ | sed -e '/^D/d' -e 's/^\w*\s//' -e '/^packages\//!d' -e 's!\([^/]*/\)\{2\}!!' -e 's!/.*!!' | sort | uniq \
         | while read PACKAGE ; do
+            # Reset env
+            opam install "$SNAPSHOT"
+
             PACKAGE_NAME="${PACKAGE%%.*}"
             SATYSFI_PACKAGE="satysfi.$(opam show --color=never -f version satysfi)"
 

--- a/ci.sh
+++ b/ci.sh
@@ -41,10 +41,8 @@ if true ; then
 
             if ! opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
             then
-                echo "Assuming dependency does not meet. Skipping"
-                echo "$PACKAGE: skipped: dependency" >> "$SUCCEEDED_PACKAGES"
+                echo "Dependency does not meet."
                 cat opam-output.json
-                continue
 
                 if [ -n "$SKIP_SATYSFI_MISMATCH" ] && jq -e '.conflicts["causes"] | index("No available version of satysfi satisfies the constraints")' opam-output.json
                 then

--- a/ci.sh
+++ b/ci.sh
@@ -34,19 +34,20 @@ if true ; then
                     SKIP_SATYSFI_MISMATCH=1
                     ;;
                 *)
-                    declare -a PACKAGES_AND_OPTIONS=('--strict' '--with-test' "$SATYSFI_PACKAGE" "$PACKAGE")
+                    declare -a PACKAGES_AND_OPTIONS=('--strict' '--with-test' "$PACKAGE")
                     SKIP_OCAML_MISMATCH=
                     SKIP_SATYSFI_MISMATCH=1
             esac
 
-            if ! opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
+            if ! opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}" "$SATYSFI_PACKAGE"
             then
                 echo "Dependency does not meet."
                 cat opam-output.json
 
-                if [ -n "$SKIP_SATYSFI_MISMATCH" ] && jq -e '.conflicts["causes"] | index("No available version of satysfi satisfies the constraints")' opam-output.json
+                if [ -n "$SKIP_SATYSFI_MISMATCH" ] && opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
                 then
-                    echo "Dependency does not meet. Skipping"
+                    echo "Can be installed with another satysfi version. Skipping."
+                    cat opam-output.json
                     echo "$PACKAGE: skipped: satysfi-dependency" >> "$SUCCEEDED_PACKAGES"
                     continue
                 else

--- a/ci.sh
+++ b/ci.sh
@@ -43,6 +43,7 @@ if true ; then
             then
                 echo "Assuming dependency does not meet. Skipping"
                 echo "$PACKAGE: skipped: dependency" >> "$SUCCEEDED_PACKAGES"
+                cat opam-output.json
                 continue
 
                 if [ -n "$SKIP_SATYSFI_MISMATCH" ] && jq -e '.conflicts["causes"] | index("No available version of satysfi satisfies the constraints")' opam-output.json

--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.1/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-azmath" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-azmath" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.2.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-slydifi" {= "%{version}%"}
-  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-easytable" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.1/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.6" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-slydifi" {= "%{version}%"}
-  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-easytable" {>= "1.0.0" & < "2.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.2.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.2.0/opam
@@ -13,8 +13,8 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-enumitem" {>= "2.0.0"}
-  "satysfi-base" {>= "1.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
+  "satysfi-base" {>= "1.0.0" & < "3.0.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.1/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.3.1/opam
@@ -11,10 +11,11 @@ dev-repo: "git+https://github.com/monaqa/slydifi.git"
 
 depends: [
   "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-enumitem" {>= "2.0.0"}
-  "satysfi-figbox" {>= "0.1.3"}
-  "satysfi-base" {>= "1.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
+  "satysfi-figbox" {>= "0.1.3" & < "1.0.0"}
+  "satysfi-base" {>= "1.0.0" & < "3.0.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.0.0/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-easytable" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-easytable" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.1/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.1/opam
@@ -20,7 +20,7 @@ depends: [
   "satysfi-dist"
   "satysfi-base"
   "satysfi-easytable" {>= "1.0.0"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
@@ -20,7 +20,7 @@ depends: [
   "satysfi-dist"
   "satysfi-base"
   "satysfi-easytable" {>= "1.0.0"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
@@ -20,7 +20,7 @@ depends: [
   "satysfi-dist"
   "satysfi-base"
   "satysfi-easytable" {>= "1.0.0"}
-  "satysfi-enumitem" {>= "2.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"


### PR DESCRIPTION
Old packages of satysfi-class-slydifi lack upper version constraints.  This PR adds them.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)