### PR TITLE
2 packages from MasWag/satysfi-parallel at 0.1.0

### DIFF
--- a/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.1.0/opam
+++ b/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Typesetting two texts in parallel"
+description: """Typesetting two texts in parallel"""
+
+maintainer: "Masaki Waga <masakiwaga@gmail.com>"
+authors: "Masaki Waga <masakiwaga@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/MasWag/satysfi-parallel"
+bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
+dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "parallel-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "parallel-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/MasWag/satysfi-parallel/releases/download/v0.1.0/package.tar.gz"
+  checksum: [
+    "md5=a58d2d0ea09305448b59f8da39b0b02a"
+    "sha512=78edf74004ffcea84d35b8719115ed41c2c81341533339c987e5576e0dbd83c23a3ec62a720c9f8b7782b0bcaf05f41b92ab1f1db031decead9feb55a4959834"
+  ]
+}

--- a/packages/satysfi-parallel/satysfi-parallel.0.1.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.1.0/opam
@@ -14,6 +14,12 @@ depends: [
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "parallel"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
    "--name" "parallel"

--- a/packages/satysfi-parallel/satysfi-parallel.0.1.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Typesetting two texts in parallel"
+description: """Typesetting two texts in parallel"""
+
+maintainer: "Masaki Waga <masakiwaga@gmail.com>"
+authors: "Masaki Waga <masakiwaga@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/MasWag/satysfi-parallel"
+bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
+dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "parallel"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/MasWag/satysfi-parallel/releases/download/v0.1.0/package.tar.gz"
+  checksum: [
+    "md5=a58d2d0ea09305448b59f8da39b0b02a"
+    "sha512=78edf74004ffcea84d35b8719115ed41c2c81341533339c987e5576e0dbd83c23a3ec62a720c9f8b7782b0bcaf05f41b92ab1f1db031decead9feb55a4959834"
+  ]
+}


### PR DESCRIPTION
Typesetting two texts in parallel

This pull-request concerns:
-`satysfi-parallel.0.1.0`
-`satysfi-parallel-doc.0.1.0`



---
* Homepage: https://github.com/MasWag/satysfi-parallel
* Source repo: git+https://github.com/MasWag/satysfi-parallel.git
* Bug tracker: https://github.com/MasWag/satysfi-parallel/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-parallel-doc.0.1.0 satysfi-parallel.0.1.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-parallel-doc.0.1.0 satysfi-parallel.0.1.0
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-parallel-doc.0.1.0 satysfi-parallel.0.1.0