### PR TITLE
2 packages from MasWag/satysfi-parallel at 0.2.0

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -39,12 +39,12 @@ if true ; then
                     SKIP_SATYSFI_MISMATCH=1
             esac
 
-            if ! opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}" "$SATYSFI_PACKAGE"
+            if ! opam install --json=opam-output.json --dry-run --cli=2.1 --update-invariant "${PACKAGES_AND_OPTIONS[@]}" "$SATYSFI_PACKAGE"
             then
                 echo "Dependency does not meet."
                 cat opam-output.json
 
-                if [ -n "$SKIP_SATYSFI_MISMATCH" ] && opam install --json=opam-output.json --dry-run --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
+                if [ -n "$SKIP_SATYSFI_MISMATCH" ] && opam install --json=opam-output.json --dry-run --cli=2.1 --update-invariant "${PACKAGES_AND_OPTIONS[@]}"
                 then
                     echo "Can be installed with another satysfi version. Skipping."
                     cat opam-output.json

--- a/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
+++ b/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+opam-version: "2.1"
 synopsis: "Typesetting two texts in parallel"
 description: """Typesetting two texts in parallel"""
 

--- a/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
+++ b/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "2.1"
+opam-version: "2.0"
 synopsis: "Typesetting two texts in parallel"
 description: """Typesetting two texts in parallel"""
 

--- a/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
+++ b/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Typesetting two texts in parallel"
+description: """Typesetting two texts in parallel"""
+
+maintainer: "Masaki Waga <masakiwaga@gmail.com>"
+authors: "Masaki Waga <masakiwaga@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/MasWag/satysfi-parallel"
+bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
+dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "parallel-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "parallel-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/MasWag/satysfi-parallel/releases/download/v0.2.0/package.tar.gz"
+  checksum: [
+    "md5=dd786870e65e5c47b051c5299d2ed766"
+    "sha512=2d23af2e19bae5b02d793f60edfc33fd72a129e5f12fbaaa6ce59fc9b219c1790bdce2078e7afaff1691b8e7c128ea2bdd1e47b9d9b8fd1619591cacb747e871"
+  ]
+}

--- a/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+opam-version: "2.1"
 synopsis: "Typesetting two texts in parallel"
 description: """Typesetting two texts in parallel"""
 

--- a/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
@@ -1,4 +1,4 @@
-opam-version: "2.1"
+opam-version: "2.0"
 synopsis: "Typesetting two texts in parallel"
 description: """Typesetting two texts in parallel"""
 

--- a/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
@@ -14,6 +14,12 @@ depends: [
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "parallel"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
    "--name" "parallel"

--- a/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Typesetting two texts in parallel"
+description: """Typesetting two texts in parallel"""
+
+maintainer: "Masaki Waga <masakiwaga@gmail.com>"
+authors: "Masaki Waga <masakiwaga@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/MasWag/satysfi-parallel"
+bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
+dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "parallel"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/MasWag/satysfi-parallel/releases/download/v0.2.0/package.tar.gz"
+  checksum: [
+    "md5=dd786870e65e5c47b051c5299d2ed766"
+    "sha512=2d23af2e19bae5b02d793f60edfc33fd72a129e5f12fbaaa6ce59fc9b219c1790bdce2078e7afaff1691b8e7c128ea2bdd1e47b9d9b8fd1619591cacb747e871"
+  ]
+}


### PR DESCRIPTION
Typesetting two texts in parallel

This pull-request concerns:
-`satysfi-parallel.0.2.0`
-`satysfi-parallel-doc.0.2.0`



---
* Homepage: https://github.com/MasWag/satysfi-parallel
* Source repo: git+https://github.com/MasWag/satysfi-parallel.git
* Bug tracker: https://github.com/MasWag/satysfi-parallel/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-parallel-doc.0.2.0 satysfi-parallel.0.2.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-parallel-doc.0.2.0 satysfi-parallel.0.2.0
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-parallel-doc.0.2.0 satysfi-parallel.0.2.0