### PR TITLE
2 packages from monaqa/slydifi at 0.5.0

### DIFF
--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.6" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-slydifi" {= "%{version}%"}
-  "satysfi-easytable" {>= "1.0.0" & < "2.0.0"}
+  "satysfi-easytable" {>= "1.0.0" & < "2.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-slydifi" {= "%{version}%"}
+  "satysfi-easytable" {>= "1.0.0" & < "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "class-slydifi-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-slydifi-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.5.0.tar.gz"
+  checksum: [
+    "md5=483bb2eb6d18aeed87e8135387755d3a"
+    "sha512=f09c32605b97c1cff72a8cc9ba1fca3b75fbde5ea58b96f2dc93597146427e775977fd37a46dab8a35ce302b80aaacc8a14079ea9c3f584cb15ca7c173fddf56"
+  ]
+}

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
@@ -12,9 +12,9 @@ dev-repo: "git+https://github.com/monaqa/slydifi.git"
 depends: [
   "satysfi" {>= "0.0.6" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-enumitem" {>= "3.0.1" & < "4.0.0"}
+  "satysfi-enumitem" {>= "3.0.1" & < "4.0"}
   "satysfi-figbox" {>= "0.1.3" & < "0.2.0"}
-  "satysfi-base" {>= "1.0.0" &  < "2.0.0"}
+  "satysfi-base" {>= "1.0.0" &  < "2.0"}
   "satysfi-railway" {>= "0.1.0" < "0.2.0"}
 ]
 install: [

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A SATySFi document class for creating presentations slides"
+description: """A SATySFi document class for creating presentations slides."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/slydifi"
+bug-reports: "https://github.com/monaqa/slydifi/issues"
+dev-repo: "git+https://github.com/monaqa/slydifi.git"
+
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-enumitem" {>= "3.0.1" & < "4.0.0"}
+  "satysfi-figbox" {>= "0.1.3" & < "0.2.0"}
+  "satysfi-base" {>= "1.0.0" &  < "2.0.0"}
+  "satysfi-railway" {>= "0.1.0" < "0.2.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "class-slydifi"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/slydifi/archive/v0.5.0.tar.gz"
+  checksum: [
+    "md5=483bb2eb6d18aeed87e8135387755d3a"
+    "sha512=f09c32605b97c1cff72a8cc9ba1fca3b75fbde5ea58b96f2dc93597146427e775977fd37a46dab8a35ce302b80aaacc8a14079ea9c3f584cb15ca7c173fddf56"
+  ]
+}


### PR DESCRIPTION
A SATySFi document class for creating presentations slides

This pull-request concerns:
-`satysfi-class-slydifi.0.5.0`
-`satysfi-class-slydifi-doc.0.5.0`



---
* Homepage: https://github.com/monaqa/slydifi
* Source repo: git+https://github.com/monaqa/slydifi.git
* Bug tracker: https://github.com/monaqa/slydifi/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-develop--1`~~ (inconsistent-snapshot +satysfi-figbox)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (inconsistent-snapshot +satysfi-figbox)