### PR TITLE
2 packages from abenori/satysfi-colorbox at 0.1.0

### DIFF
--- a/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.0/opam
+++ b/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of Colorbox"
+description: """Document of Colorbox package"""
+maintainer: "Noriyuki Abe"
+authors: "Noriyuki Abe"
+license: "BSD-2-Clause-Views"
+homepage: "https://github.com/abenori/satysfi-colorbox"
+dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
+bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "1.0.0" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-enumitem" {>= "3.0.0" & < "3.1.0" }
+
+  # You may want to include the corresponding library
+  "satysfi-colorbox" {= "%{version}%"}
+  "satysfi-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "colorbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "colorbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-colorbox/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=224ea91e4fdec7f8c59f2aecfa2f1a00"
+    "sha512=954e4e7f96b2ecdb94a21cf39e88acaa961103c50dc821dda48e67f3ef5b19085c310be416defd726cf68f6d5d2bd3853ac452bba648f8ebc27b4112cc68347c"
+  ]
+}

--- a/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.0/opam
+++ b/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.0/opam
@@ -8,9 +8,9 @@ homepage: "https://github.com/abenori/satysfi-colorbox"
 dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
 bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "1.0.0" }
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
-  "satysfi-enumitem" {>= "3.0.0" & < "3.1.0" }
+  "satysfi-enumitem" {>= "3.0.0" & < "3.1" }
 
   # You may want to include the corresponding library
   "satysfi-colorbox" {= "%{version}%"}

--- a/packages/satysfi-colorbox/satysfi-colorbox.0.1.0/opam
+++ b/packages/satysfi-colorbox/satysfi-colorbox.0.1.0/opam
@@ -8,12 +8,12 @@ homepage: "https://github.com/abenori/satysfi-colorbox"
 dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
 bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "1.0.0" }
+  "satysfi" { >= "0.0.6" & < "0.0.7" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
+  "satysfi-base" { >= "1.4.0" & < "2.0" }
   "satysfi-fss" { >= "0.2.0" & < "0.3.0" }
 ]
 build: [

--- a/packages/satysfi-colorbox/satysfi-colorbox.0.1.0/opam
+++ b/packages/satysfi-colorbox/satysfi-colorbox.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package for Colored boxes"
+description: """A SATySFi package for Colored boxes"""
+maintainer: "Noriyuki Abe"
+authors: "Noriyuki Abe"
+license: "BSD-2-Clause-Views"
+homepage: "https://github.com/abenori/satysfi-colorbox"
+dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
+bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "1.0.0" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
+  "satysfi-fss" { >= "0.2.0" & < "0.3.0" }
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "colorbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "colorbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-colorbox/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=224ea91e4fdec7f8c59f2aecfa2f1a00"
+    "sha512=954e4e7f96b2ecdb94a21cf39e88acaa961103c50dc821dda48e67f3ef5b19085c310be416defd726cf68f6d5d2bd3853ac452bba648f8ebc27b4112cc68347c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-colorbox.0.1.0`: A SATySFi package for Colored boxes
-`satysfi-colorbox-doc.0.1.0`: Document of Colorbox



---
* Homepage: https://github.com/abenori/satysfi-colorbox
* Source repo: git+https://github.com/abenori/satysfi-colorbox.git
* Bug tracker: https://github.com/abenori/satysfi-colorbox/issues

---
:camel: Pull-request generated by opam-publish v2.0.3
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-colorbox-doc.0.1.0 satysfi-colorbox.0.1.0
- Add to snapshot `snapshot-stable-0-0-4`
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-colorbox-doc.0.1.0 satysfi-colorbox.0.1.0