### PR TITLE
Add new snapshot minor versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,11 @@ jobs:
           - 4.11.1
           - 4.12.0
         snapshot:
+          - develop--1
+          - develop
+          - stable-0-0-6--1
           - stable-0-0-6
           - stable-0-0-5
-          - develop
         include:
           - os: 'ubuntu-latest'
             ocaml-version: '4.06.1'

--- a/scripts/take-snapshot
+++ b/scripts/take-snapshot
@@ -38,12 +38,13 @@ take_snapshots () {
 	local CALLBACK="$1"
 	shift
 	for OPAM_FILE in "$@" ; do
+    TAG="$(echo "$OPAM_FILE" | sed -e 's/\.opam$//; s/--/@/g; s/[^@]*\(@\|$\)/\1/; s/@/-/g')"
 		case "$OPAM_FILE" in
 			snapshot-develop*)
-				take_snapshot "$OPAM_FILE" "satyrographos-snapshot-develop" "" "$CALLBACK"
+				take_snapshot "$OPAM_FILE" "satyrographos-snapshot-develop" "$TAG" "$CALLBACK"
 				;;
 			snapshot-stable-*)
-				take_snapshot "$OPAM_FILE" "satyrographos-snapshot-stable" "" "$CALLBACK"
+				take_snapshot "$OPAM_FILE" "satyrographos-snapshot-stable" "$TAG" "$CALLBACK"
 				;;
 		esac
 	done

--- a/snapshot-develop--1.opam
+++ b/snapshot-develop--1.opam
@@ -1,0 +1,254 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos-repo"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
+license: "CC0"
+
+synopsis: "Snapshot of stable libraries in Satyrographos Repo"
+
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.10.0"}
+  "satysfi" {= "0.0.6-53-g2867e4d9"}
+  "satysfi-dist"
+  "satyrographos" {= "0.0.2.11"}
+
+
+# Package List
+
+  "satysfi-arrows-doc" {= "0.1.0"}
+
+  "satysfi-arrows" {= "0.1.0"}
+
+  "satysfi-assert-eq-doc" {= "0.1.2"}
+
+  "satysfi-assert-eq" {= "0.1.2"}
+
+  "satysfi-base" {= "1.4.0"}
+
+  "satysfi-bibyfi-doc" {= "0.0.2"}
+
+  "satysfi-bibyfi" {= "0.0.2"}
+
+  "satysfi-cancel" {= "0.0.1"}
+
+  "satysfi-class-exdesign-doc" {= "0.3.1"}
+
+  "satysfi-class-exdesign" {= "0.3.1"}
+
+  "satysfi-class-jlreq" {= "0.0.3"}
+
+  "satysfi-class-mdbook-satysfi-doc" {= "0.3.0"}
+
+  "satysfi-class-mdbook-satysfi" {= "0.3.0"}
+
+  "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
+  "satysfi-class-stjarticle" {= "1.3.2"}
+
+  "satysfi-class-yabaitech-doc" {= "0.0.8"}
+
+  "satysfi-class-yabaitech" {= "0.0.8"}
+
+  "satysfi-code-printer-doc" {= "1.0.0"}
+
+  "satysfi-code-printer" {= "1.0.0"}
+
+  "satysfi-csv-doc" {= "1.0.0"}
+
+  "satysfi-csv" {= "1.0.0"}
+
+  "satysfi-debug-show-value-doc" {= "0.1.2"}
+
+  "satysfi-debug-show-value" {= "0.1.2"}
+
+  "satysfi-derive" {= "1.0.0"}
+
+  "satysfi-enumitem-doc" {= "3.0.1"}
+
+  "satysfi-enumitem" {= "3.0.1"}
+
+  "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-bodoni-star-doc" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-charis-sil-doc" {= "1.0.0"}
+
+  "satysfi-fonts-charis-sil" {= "1.0.0"}
+
+  "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-han-sans-jp-doc" {= "2.003R"}
+
+  "satysfi-fonts-han-sans-jp" {= "2.003R"}
+
+  "satysfi-fonts-han-serif-jp-doc" {= "1.001R"}
+
+  "satysfi-fonts-han-serif-jp" {= "1.001R"}
+
+  "satysfi-fonts-inconsolata-doc" {= "3.001"}
+
+  "satysfi-fonts-inconsolata" {= "3.001"}
+
+  "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fss-doc" {= "0.2.0"}
+
+  "satysfi-fss-fontset-bodoni-star" {= "2.3"}
+
+  "satysfi-fss" {= "0.2.0"}
+
+  "satysfi-grcnum-doc" {= "0.2"}
+
+  "satysfi-grcnum" {= "0.2"}
+
+  "satysfi-image-doc" {= "0.1.0"}
+
+  "satysfi-image" {= "0.1.0"}
+
+  "satysfi-json-doc" {= "1.0.1"}
+
+  "satysfi-json" {= "1.0.1"}
+
+  "satysfi-karnaugh-doc" {= "0.0.1"}
+
+  "satysfi-karnaugh" {= "0.0.1"}
+
+  "satysfi-latexcmds-doc" {= "0.1.0"}
+
+  "satysfi-latexcmds" {= "0.1.0"}
+
+  "satysfi-lipsum-doc" {= "0.2.1"}
+
+  "satysfi-lipsum" {= "0.2.1"}
+
+  "satysfi-make-html-doc" {= "0.1.1"}
+
+  "satysfi-make-html" {= "0.1.1"}
+
+  "satysfi-make-latex-doc" {= "0.2.0"}
+
+  "satysfi-make-latex" {= "0.2.0"}
+
+  "satysfi-make-markdown" {= "0.1.0"}
+
+  "satysfi-matrixcd" {= "0.0.3"}
+
+  "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-md2latex-doc" {= "0.0.3"}
+
+  "satysfi-md2latex" {= "0.0.3"}
+
+  "satysfi-musikui-doc" {= "0.1.1"}
+
+  "satysfi-musikui" {= "0.1.1"}
+
+  "satysfi-ncsq-doc" {= "2.1.0"}
+
+  "satysfi-ncsq" {= "2.1.0"}
+
+  "satysfi-num-conversion-doc" {= "0.1.4"}
+
+  "satysfi-num-conversion" {= "0.1.4"}
+
+  "satysfi-pagenumber-doc" {= "1.0.0"}
+
+  "satysfi-pagenumber" {= "1.0.0"}
+
+  "satysfi-pagestyle-doc" {= "1.0.0"}
+
+  "satysfi-pagestyle" {= "1.0.0"}
+
+  "satysfi-parallel-doc" {= "0.1.0"}
+
+  "satysfi-parallel" {= "0.1.0"}
+
+  "satysfi-quotation-doc" {= "0.2.0"}
+
+  "satysfi-quotation" {= "0.2.0"}
+
+  "satysfi-railway-doc" {= "0.1.0"}
+
+  "satysfi-railway" {= "0.1.0"}
+
+  "satysfi-ruby-doc" {= "0.1.2"}
+
+  "satysfi-ruby" {= "0.1.2"}
+
+  "satysfi-simple-itemize-doc" {= "1.0.2"}
+
+  "satysfi-simple-itemize" {= "1.0.2"}
+
+  "satysfi-siunitx-doc" {= "0.1.1"}
+
+  "satysfi-siunitx" {= "0.1.1"}
+
+  "satysfi-test" {= "0.0.1"}
+
+  "satysfi-texlogo-doc" {= "0.1.1"}
+
+  "satysfi-texlogo" {= "0.1.1"}
+
+  "satysfi-tombo-doc" {= "0.2.0"}
+
+  "satysfi-tombo" {= "0.2.0"}
+
+  "satysfi-uline-doc" {= "0.2.2"}
+
+  "satysfi-uline" {= "0.2.2"}
+
+  "satysfi-zrbase" {= "0.4.0"}
+
+# Package List End
+]

--- a/snapshot-stable-0-0-6--1.opam
+++ b/snapshot-stable-0-0-6--1.opam
@@ -1,0 +1,250 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos-repo"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
+license: "CC0"
+
+synopsis: "Snapshot of stable libraries in Satyrographos Repo"
+
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.10.0"}
+  "satysfi" {= "0.0.6"}
+  "satysfi-dist"
+  "satyrographos" {= "0.0.2.11"}
+
+
+# Package List
+
+  "satysfi-arrows-doc" {= "0.1.0"}
+
+  "satysfi-arrows" {= "0.1.0"}
+
+  "satysfi-assert-eq-doc" {= "0.1.2"}
+
+  "satysfi-assert-eq" {= "0.1.2"}
+
+  "satysfi-base" {= "1.4.0"}
+
+  "satysfi-bibyfi-doc" {= "0.0.2"}
+
+  "satysfi-bibyfi" {= "0.0.2"}
+
+  "satysfi-cancel" {= "0.0.1"}
+
+  "satysfi-class-exdesign-doc" {= "0.3.1"}
+
+  "satysfi-class-exdesign" {= "0.3.1"}
+
+  "satysfi-class-jlreq" {= "0.0.3"}
+
+  "satysfi-class-mdbook-satysfi-doc" {= "0.3.0"}
+
+  "satysfi-class-mdbook-satysfi" {= "0.3.0"}
+
+  "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
+  "satysfi-class-stjarticle" {= "1.3.2"}
+
+  "satysfi-class-yabaitech-doc" {= "0.0.8"}
+
+  "satysfi-class-yabaitech" {= "0.0.8"}
+
+  "satysfi-csv-doc" {= "1.0.0"}
+
+  "satysfi-csv" {= "1.0.0"}
+
+  "satysfi-debug-show-value-doc" {= "0.1.2"}
+
+  "satysfi-debug-show-value" {= "0.1.2"}
+
+  "satysfi-derive" {= "1.0.0"}
+
+  "satysfi-enumitem-doc" {= "3.0.1"}
+
+  "satysfi-enumitem" {= "3.0.1"}
+
+  "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-bodoni-star-doc" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-charis-sil-doc" {= "1.0.0"}
+
+  "satysfi-fonts-charis-sil" {= "1.0.0"}
+
+  "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-han-sans-jp-doc" {= "2.003R"}
+
+  "satysfi-fonts-han-sans-jp" {= "2.003R"}
+
+  "satysfi-fonts-han-serif-jp-doc" {= "1.001R"}
+
+  "satysfi-fonts-han-serif-jp" {= "1.001R"}
+
+  "satysfi-fonts-inconsolata-doc" {= "3.001"}
+
+  "satysfi-fonts-inconsolata" {= "3.001"}
+
+  "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fss-doc" {= "0.2.0"}
+
+  "satysfi-fss-fontset-bodoni-star" {= "2.3"}
+
+  "satysfi-fss" {= "0.2.0"}
+
+  "satysfi-grcnum-doc" {= "0.2"}
+
+  "satysfi-grcnum" {= "0.2"}
+
+  "satysfi-image-doc" {= "0.1.0"}
+
+  "satysfi-image" {= "0.1.0"}
+
+  "satysfi-json-doc" {= "1.0.1"}
+
+  "satysfi-json" {= "1.0.1"}
+
+  "satysfi-karnaugh-doc" {= "0.0.1"}
+
+  "satysfi-karnaugh" {= "0.0.1"}
+
+  "satysfi-latexcmds-doc" {= "0.1.0"}
+
+  "satysfi-latexcmds" {= "0.1.0"}
+
+  "satysfi-lipsum-doc" {= "0.2.1"}
+
+  "satysfi-lipsum" {= "0.2.1"}
+
+  "satysfi-make-html-doc" {= "0.1.1"}
+
+  "satysfi-make-html" {= "0.1.1"}
+
+  "satysfi-make-latex-doc" {= "0.2.0"}
+
+  "satysfi-make-latex" {= "0.2.0"}
+
+  "satysfi-make-markdown" {= "0.1.0"}
+
+  "satysfi-matrixcd" {= "0.0.3"}
+
+  "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-md2latex-doc" {= "0.0.3"}
+
+  "satysfi-md2latex" {= "0.0.3"}
+
+  "satysfi-musikui-doc" {= "0.1.1"}
+
+  "satysfi-musikui" {= "0.1.1"}
+
+  "satysfi-ncsq-doc" {= "2.1.0"}
+
+  "satysfi-ncsq" {= "2.1.0"}
+
+  "satysfi-num-conversion-doc" {= "0.1.4"}
+
+  "satysfi-num-conversion" {= "0.1.4"}
+
+  "satysfi-pagenumber-doc" {= "1.0.0"}
+
+  "satysfi-pagenumber" {= "1.0.0"}
+
+  "satysfi-pagestyle-doc" {= "1.0.0"}
+
+  "satysfi-pagestyle" {= "1.0.0"}
+
+  "satysfi-parallel-doc" {= "0.1.0"}
+
+  "satysfi-parallel" {= "0.1.0"}
+
+  "satysfi-quotation-doc" {= "0.2.0"}
+
+  "satysfi-quotation" {= "0.2.0"}
+
+  "satysfi-railway-doc" {= "0.1.0"}
+
+  "satysfi-railway" {= "0.1.0"}
+
+  "satysfi-ruby-doc" {= "0.1.2"}
+
+  "satysfi-ruby" {= "0.1.2"}
+
+  "satysfi-simple-itemize-doc" {= "1.0.2"}
+
+  "satysfi-simple-itemize" {= "1.0.2"}
+
+  "satysfi-siunitx-doc" {= "0.1.1"}
+
+  "satysfi-siunitx" {= "0.1.1"}
+
+  "satysfi-test" {= "0.0.1"}
+
+  "satysfi-texlogo-doc" {= "0.1.1"}
+
+  "satysfi-texlogo" {= "0.1.1"}
+
+  "satysfi-tombo-doc" {= "0.2.0"}
+
+  "satysfi-tombo" {= "0.2.0"}
+
+  "satysfi-uline-doc" {= "0.2.2"}
+
+  "satysfi-uline" {= "0.2.2"}
+
+  "satysfi-zrbase" {= "0.4.0"}
+
+# Package List End
+]


### PR DESCRIPTION
This PR adds new snapshots with minor versions:

- develop--1
- stable-0-0-6--1

Those snapshot will have package names `satyrographos-snapshot-${DEVELOP_OR_STABLE}-${SATYSFI_VERSION}-1+${DATE}`.

Closes https://github.com/na4zagin3/satyrographos-repo/issues/394

The new snapshots were created without

- azmath
- class-slydifi
- easytable
- figbox

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)