### PR TITLE
Properly ignore non-follow-up part in body

### DIFF
--- a/.github/workflows/pr-followup.yaml
+++ b/.github/workflows/pr-followup.yaml
@@ -40,10 +40,11 @@ jobs:
 
       - name: Update snapshots
         run: |
+          set -exo pipefail
           git branch -v
           git remote -v
           git log -n 2
-          echo "$PR" | jq -r '.body' | sed -e '/^- /!d' -e 's/^- \[[xX]\] Add to snapshot `\([^`]*\)` :: /\1.opam /' -e '/^[-+. [:alnum:]]*$/!d' | xargs -r -L1 scripts/update-snapshot --base 'origin/master~1' --opam
+          echo "$PR" | jq -r '.body' | sed -e '1,/^# Automatic follow-ups$/d' -e '/^- /!d' -e 's/^- \[[xX]\] Add to snapshot `\([^`]*\)` :: /\1.opam -- /' -e '/^[-+. [:alnum:]]*$/!d' | xargs -r -L1 scripts/update-snapshot --base 'origin/master~1' --opam
           git status
         env:
           PR: ${{ steps.head-branch.outputs.result }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: List up snapshots
         id: snapshots
         run: |
-            echo "::set-output name=snapshots::$(ls snapshot-*.opam | sed -e 's/\.opam$//' | tr '\n' ' ')"
+            echo "::set-output name=snapshots::$(ls -1 snapshot-*.opam | sed -e 's/\.opam$//' | sort -n | tr '\n' ' ')"
 
       - name: Update the PR body
         uses: actions/github-script@v2


### PR DESCRIPTION
This addresses the error https://github.com/na4zagin3/satyrographos-repo/actions/runs/1595868860 caused by itemization in https://github.com/na4zagin3/satyrographos-repo/pull/400

- test test
- test

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)