### PR TITLE
Fix flipped skip conditions

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -90,11 +90,11 @@ if true ; then
             then
                 echo "$PACKAGE: satyrographos" >> "$FAILED_PACKAGES"
                 continue
-            elif [ -n "$SKIP_OLDEST_DEPS" ] && ! opam install $(opam exec -- opam-0install --prefer-oldest "$PACKAGE" "$SATYSFI_PACKAGE" "$OCAML_PACKAGE")
+            elif [ -z "$SKIP_OLDEST_DEPS" ] && ! opam install $(opam exec -- opam-0install --prefer-oldest "$PACKAGE" "$SATYSFI_PACKAGE" "$OCAML_PACKAGE")
             then
                 echo "$PACKAGE: install-with-oldest-deps" >> "$FAILED_PACKAGES"
                 continue
-            elif [ -n "$SKIP_OLDEST_DEPS" ] && ! opam exec -- satyrographos install
+            elif [ -z "$SKIP_OLDEST_DEPS" ] && ! opam exec -- satyrographos install
             then
                 echo "$PACKAGE: satyrographos-with-oldest-deps" >> "$FAILED_PACKAGES"
                 continue


### PR DESCRIPTION
Currently old-deps steps are skipped because of the flipped condition.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- Add to snapshot `snapshot-develop--1`
- Add to snapshot `snapshot-stable-0-0-4`
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`
- Add to snapshot `snapshot-stable-0-0-6--1`