### PR TITLE
Bump version constraints on enumitem

### DIFF
--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-azmath" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "4.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-easytable" {= "%{version}%"}
-  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "4.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
@@ -20,7 +20,7 @@ depends: [
   "satysfi-dist"
   "satysfi-base"
   "satysfi-easytable" {>= "1.0.0"}
-  "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
+  "satysfi-enumitem" {>= "2.0.0" & < "4.0.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/snapshot-develop--1.opam
+++ b/snapshot-develop--1.opam
@@ -28,6 +28,8 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.4.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}
@@ -68,9 +70,13 @@ depends: [
 
   "satysfi-derive" {= "1.0.0"}
 
+  "satysfi-easytable" {= "1.1.1"}
+
   "satysfi-enumitem-doc" {= "3.0.1"}
 
   "satysfi-enumitem" {= "3.0.1"}
+
+  "satysfi-figbox" {= "0.1.3"}
 
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
 

--- a/snapshot-stable-0-0-6--1.opam
+++ b/snapshot-stable-0-0-6--1.opam
@@ -28,6 +28,8 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.4.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}
@@ -64,9 +66,13 @@ depends: [
 
   "satysfi-derive" {= "1.0.0"}
 
+  "satysfi-easytable" {= "1.1.1"}
+
   "satysfi-enumitem-doc" {= "3.0.1"}
 
   "satysfi-enumitem" {= "3.0.1"}
+
+  "satysfi-figbox" {= "0.1.3"}
 
   "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
 


### PR DESCRIPTION
This commit bumps version constraints on enumitem of doc libraries and restore their corresponding package libraries to the snapshots.
Cf. https://github.com/na4zagin3/satyrographos-repo/pull/400
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- Add to snapshot `snapshot-develop--1`
- Add to snapshot `snapshot-stable-0-0-4`
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`
- Add to snapshot `snapshot-stable-0-0-6--1`