### PR TITLE
Temporarily disable OCaml 4.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         ocaml-version:
 #         - 4.10.1
           - 4.11.1
-          - 4.12.0
+#         - 4.12.0
         snapshot:
           - develop--1
           - develop


### PR DESCRIPTION
We need to disable build against OCaml 4.12 until https://github.com/ocaml/opam-repository/pull/20284 is merged
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)