### PR TITLE
Skip oldest-deps check when opam-0install fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ jobs:
           # Workaround https://github.com/na4zagin3/satyrographos/issues/287
           OPAMJOBS: 1
         run: |
+          # Workaround until https://github.com/ocaml/opam-repository/pull/20284 is merged
+          export SKIP_OLDEST_DEPS=1
           ./ci.sh
 
       - name: Test if the packages can be added to the snapshot

--- a/ci.sh
+++ b/ci.sh
@@ -11,8 +11,9 @@ SUCCEEDED_PACKAGES=succeeded.pkgs
 
 OCAML_PACKAGE="ocaml.$(opam show --color=never -f version ocaml)"
 
-if ! opam install opam-0install
+if ! opam install opam-0install || ! opam exec -- opam-0install satyrographos
 then
+    echo "Skipping oldest-deps check"
     SKIP_OLDEST_DEPS=1
 else
     SKIP_OLDEST_DEPS=
@@ -103,7 +104,7 @@ if true ; then
                 echo "$PACKAGE: uninstall" >> "$FAILED_PACKAGES"
             fi
 
-            echo "$PACKAGE: success" >> "$SUCCEEDED_PACKAGES"
+            echo "$PACKAGE: success" ${SKIP_OLDEST_DEPS+skip-oldest-deps} >> "$SUCCEEDED_PACKAGES"
         done
     else
         echo "Non pull request"

--- a/ci.sh
+++ b/ci.sh
@@ -11,7 +11,7 @@ SUCCEEDED_PACKAGES=succeeded.pkgs
 
 OCAML_PACKAGE="ocaml.$(opam show --color=never -f version ocaml)"
 
-if ! opam install opam-0install || ! opam exec -- opam-0install satyrographos
+if [ -n "$SKIP_OLDEST_DEPS" ] || ! opam install opam-0install
 then
     echo "Skipping oldest-deps check"
     SKIP_OLDEST_DEPS=1

--- a/ci.sh
+++ b/ci.sh
@@ -104,7 +104,7 @@ if true ; then
                 echo "$PACKAGE: uninstall" >> "$FAILED_PACKAGES"
             fi
 
-            echo "$PACKAGE: success" ${SKIP_OLDEST_DEPS+skip-oldest-deps} >> "$SUCCEEDED_PACKAGES"
+            echo "$PACKAGE: success" ${SKIP_OLDEST_DEPS:+skip-oldest-deps} >> "$SUCCEEDED_PACKAGES"
         done
     else
         echo "Non pull request"


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)