### PR TITLE
Add back easytable.1.1.1 to the snapshots

### DIFF
--- a/snapshot-develop--1.opam
+++ b/snapshot-develop--1.opam
@@ -68,6 +68,8 @@ depends: [
 
   "satysfi-derive" {= "1.0.0"}
 
+  "satysfi-easytable" {= "1.1.1"}
+
   "satysfi-enumitem-doc" {= "3.0.1"}
 
   "satysfi-enumitem" {= "3.0.1"}

--- a/snapshot-stable-0-0-6--1.opam
+++ b/snapshot-stable-0-0-6--1.opam
@@ -64,6 +64,8 @@ depends: [
 
   "satysfi-derive" {= "1.0.0"}
 
+  "satysfi-easytable" {= "1.1.1"}
+
   "satysfi-enumitem-doc" {= "3.0.1"}
 
   "satysfi-enumitem" {= "3.0.1"}


### PR DESCRIPTION
Other libraries in the snapshots depend on easytable.

Ideally, easytable should be removed from the snapshots until its test library (i.e., doc library for Satyrographos 0.0.2) is restored, but we cannot do that.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)