### PR TITLE
Fix wrong lower version of satysfi-fonts-inconsolata

### DIFF
--- a/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
@@ -20,7 +20,7 @@ extra-source "inconsolata.zip" {
 }
 depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [
   ["unzip" "-j" "-d" "inconsolata" "-o" "inconsolata.zip" "*.ttf"]


### PR DESCRIPTION
satysfi-fonts-inconsolata's lower version of Satyrographos is wrong.  This commit fixes it.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)