### PR TITLE
2 packages from abenori/satysfi-colorbox at 0.1.1

### DIFF
--- a/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.1/opam
+++ b/packages/satysfi-colorbox-doc/satysfi-colorbox-doc.0.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Document of Colorbox"
+description: """Document of Colorbox package"""
+maintainer: "Noriyuki Abe"
+authors: "Noriyuki Abe"
+license: "MIT"
+homepage: "https://github.com/abenori/satysfi-colorbox"
+dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
+bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.1" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  "satysfi-enumitem" {>= "3.0.0" & < "3.1" }
+
+  # You may want to include the corresponding library
+  "satysfi-colorbox" {= "%{version}%"}
+  "satysfi-dist"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "colorbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "colorbox-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-colorbox/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=4825a8b97cbc724dba5faf6ecf79b030"
+    "sha512=f427ce1fad7971fbb104ca58e275fc037efbd84a5ffed90bc75fd83e00c7fc833a83c23810f96396abea64c4ede5077bbe7aaad1f7d156e494fb8a64720675cf"
+  ]
+}

--- a/packages/satysfi-colorbox/satysfi-colorbox.0.1.1/opam
+++ b/packages/satysfi-colorbox/satysfi-colorbox.0.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package for Colored boxes"
+description: """A SATySFi package for Colored boxes"""
+maintainer: "Noriyuki Abe"
+authors: "Noriyuki Abe"
+license: "MIT"
+homepage: "https://github.com/abenori/satysfi-colorbox"
+dev-repo: "git+https://github.com/abenori/satysfi-colorbox.git"
+bug-reports: "https://github.com/abenori/satysfi-colorbox/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.1" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base" { >= "1.4.0" & < "2.0" }
+  "satysfi-fss" { >= "0.2.0" & < "0.3" }
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "colorbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "colorbox"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-colorbox/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=4825a8b97cbc724dba5faf6ecf79b030"
+    "sha512=f427ce1fad7971fbb104ca58e275fc037efbd84a5ffed90bc75fd83e00c7fc833a83c23810f96396abea64c4ede5077bbe7aaad1f7d156e494fb8a64720675cf"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-colorbox.0.1.1`: A SATySFi package for Colored boxes
-`satysfi-colorbox-doc.0.1.1`: Document of Colorbox



---
* Homepage: https://github.com/abenori/satysfi-colorbox
* Source repo: git+https://github.com/abenori/satysfi-colorbox.git
* Bug tracker: https://github.com/abenori/satysfi-colorbox/issues

---
:camel: Pull-request generated by opam-publish v2.1.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-colorbox-doc.0.1.1 satysfi-colorbox.0.1.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-colorbox-doc.0.1.1 satysfi-colorbox.0.1.1