### PR TITLE
2 packages from yasuo-ozu/satysfi-xpath at 0.2.0

### DIFF
--- a/packages/satysfi-xpath-doc/satysfi-xpath-doc.0.2.0/opam
+++ b/packages/satysfi-xpath-doc/satysfi-xpath-doc.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Docs of advanced path algorithms in SATySFi"
+description: """Docs of advanced path algorithms in SATySFi"""
+
+maintainer: "Yasuo Ozu <yasuo@ozu.email>"
+authors: "Yasuo Ozu <yasuo@ozu.email>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/yasuo-ozu/satysfi-xpath"
+bug-reports: "https://github.com/yasuo-ozu/satysfi-xpath/issues"
+dev-repo: "git+https://github.com/yasuo-ozu/satysfi-xpath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satysfi-xpath"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "xpath-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "xpath-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/yasuo-ozu/satysfi-xpath/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=8e3c25e773e1ba012fafb0a59f552f47"
+    "sha512=b7bea1d05b4019d6314ef17e036bd543aa6238ddf6ab3cd58d975a7293e4df715100bd146119b5ac4eba9319d2e8738a85a03b7c74adaf33f95ec2df56a63499"
+  ]
+}
+

--- a/packages/satysfi-xpath-doc/satysfi-xpath-doc.0.2.0/opam
+++ b/packages/satysfi-xpath-doc/satysfi-xpath-doc.0.2.0/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/yasuo-ozu/satysfi-xpath.git"
 depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satysfi-dist"
-  "satysfi-xpath"
+  "satysfi-xpath" {= "%{version}%"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-xpath/satysfi-xpath.0.2.0/opam
+++ b/packages/satysfi-xpath/satysfi-xpath.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Advanced path algorithms in SATySFi"
+description: """Advanced path algorithms in SATySFi"""
+
+maintainer: "Yasuo Ozu <yasuo@ozu.email>"
+authors: "Yasuo Ozu <yasuo@ozu.email>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/yasuo-ozu/satysfi-xpath"
+bug-reports: "https://github.com/yasuo-ozu/satysfi-xpath/issues"
+dev-repo: "git+https://github.com/yasuo-ozu/satysfi-xpath.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "xpath"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/yasuo-ozu/satysfi-xpath/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=8e3c25e773e1ba012fafb0a59f552f47"
+    "sha512=b7bea1d05b4019d6314ef17e036bd543aa6238ddf6ab3cd58d975a7293e4df715100bd146119b5ac4eba9319d2e8738a85a03b7c74adaf33f95ec2df56a63499"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-xpath.0.2.0`: Advanced path algorithms in SATySFi
-`satysfi-xpath-doc.0.2.0`: Docs of advanced path algorithms in SATySFi



---
* Homepage: https://github.com/yasuo-ozu/satysfi-xpath
* Source repo: git+https://github.com/yasuo-ozu/satysfi-xpath.git
* Bug tracker: https://github.com/yasuo-ozu/satysfi-xpath/issues

---
:camel: Pull-request generated by opam-publish v2.1.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-xpath-doc.0.2.0 satysfi-xpath.0.2.0
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-xpath-doc.0.2.0 satysfi-xpath.0.2.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-xpath-doc.0.2.0 satysfi-xpath.0.2.0
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-xpath-doc.0.2.0 satysfi-xpath.0.2.0
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-xpath-doc.0.2.0 satysfi-xpath.0.2.0