### PR TITLE
Add SATySFi 0.0.7

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.7/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.7/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "gfngfn"
+]
+extra-source "temp/lm2.004otf.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  checksum: [
+    "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
+    "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
+  ]
+}
+extra-source "temp/latinmodern-math-1959.zip" {
+  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  checksum: [
+    "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
+    "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"
+  ]
+}
+extra-source "temp/junicode-1.002.zip" {
+  archive: "http://downloads.sourceforge.net/project/junicode/junicode/junicode-1.002/junicode-1.002.zip"
+  checksum: [
+    "sha256=c199d96c8424be60fcab8d00d2eee39ea8ae632cfd5e710cbbd70626d6a729e7"
+    "sha512=1738802f70b0029567be608ed36481864f8f7f029fd1c45d73fa25d092d49c978c51df1c01147b7b176e9b0409d7f15d5713a6daf1b1b269636bc6324b2c6f37"
+  ]
+}
+extra-source "temp/IPAexfont00401.zip" {
+  archive: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
+  mirrors: [
+    "https://github.com/na4zagin3/satysfi-dist-font-archives/raw/master/IPAJ/IPAexfont00401.zip"
+  ]
+  checksum: [
+    "sha256=bcf8374ab3f9672c421120430dd19a51c99f5265cf06fc340d9a661ddfd7974b"
+    "sha512=fe639ded0a25eed66df8cc1e9d5e965b501574a25fab542a749b3cb8464690448e44343ff5845aecd3224ec481c4089ee56e64880cbbc9211a260b22d4cc68cd"
+  ]
+}
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["./download-fonts.sh"]
+]
+install: [
+  ["./install-libs.sh" "%{share}%/satysfi"]
+]
+remove: [
+  ["rm" "-rf" "%{share}%/satysfi/dist"]
+]
+depends: [
+  "satysfi" {= "%{version}%" }
+]
+synopsis: "Standard library of SATySFi"
+description: """
+Provides the standard library of SATySFi"""
+url {
+  src: "https://github.com/gfngfn/SATySFi/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: [
+    "sha512=807868e20b5b27e1e84a50d14af9e03bfd0ffdc5bac7635c58b416e369b7da56bf6f8e16df06b517a7ab586dbdac41fe32d36fe7bf0c036a7d845515425ab7ab"
+  ]
+}

--- a/packages/satysfi/satysfi.0.0.7/opam
+++ b/packages/satysfi/satysfi.0.0.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "gfngfn"
+authors: [
+  "gfngfn"
+]
+homepage: "https://github.com/gfngfn/SATySFi"
+dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
+bug-reports: "https://github.com/gfngfn/SATySFi/issues"
+build: [
+  ["mkdir" "-p" "temp"]
+  [make "-f" "Makefile" "PREFIX=%{prefix}%"]
+]
+install: [
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%"]
+]
+remove: [
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%"]
+]
+# Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "batteries"
+  "camlimages" {>= "5.0.1"}
+  "camlpdf" {= "2.3.1+satysfi"}
+  "core_kernel" {>= "v0.13" & < "v0.15"}
+  "cppo" {build & >= "1.6.4" & < "1.7.0"}
+  "dune" {build}
+  "menhir"
+  "ocamlfind" {build}
+  "otfm" {= "0.3.7+satysfi"}
+  "ppx_deriving"
+  "re" {build}
+  "uutf"
+  "yojson-with-position" {= "1.4.2+satysfi"}
+  "omd" {< "2.0.0~"}
+]
+synopsis: "A statically-typed, functional typesetting system"
+description: """
+SATySFi is a typesetting system equipped with a statically-typed, functional programming language. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has OCaml-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""
+url {
+  src: "https://github.com/gfngfn/SATySFi/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: [
+    "sha512=807868e20b5b27e1e84a50d14af9e03bfd0ffdc5bac7635c58b416e369b7da56bf6f8e16df06b517a7ab586dbdac41fe32d36fe7bf0c036a7d845515425ab7ab"
+  ]
+}

--- a/snapshot-stable-0-0-7.opam
+++ b/snapshot-stable-0-0-7.opam
@@ -1,0 +1,268 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos-repo"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos-repo.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos-repo/issues"
+license: "CC0"
+
+synopsis: "Snapshot of stable libraries in Satyrographos Repo"
+
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.10.0"}
+  "satysfi" {= "0.0.7"}
+  "satysfi-dist"
+  "satyrographos" {= "0.0.2.11"}
+
+
+# Package List
+
+  "satysfi-arrows-doc" {= "0.1.0"}
+
+  "satysfi-arrows" {= "0.1.0"}
+
+  "satysfi-assert-eq-doc" {= "0.1.2"}
+
+  "satysfi-assert-eq" {= "0.1.2"}
+
+  "satysfi-base" {= "1.4.0"}
+
+  "satysfi-bibyfi-doc" {= "0.0.2"}
+
+  "satysfi-bibyfi" {= "0.0.2"}
+
+  "satysfi-cancel" {= "0.0.1"}
+
+  "satysfi-class-cv-doc" {= "0.1.0"}
+
+  "satysfi-class-cv" {= "0.1.0"}
+
+  "satysfi-class-exdesign-doc" {= "0.3.1"}
+
+  "satysfi-class-exdesign" {= "0.3.1"}
+
+  "satysfi-class-jlreq" {= "0.0.3"}
+
+  "satysfi-class-mdbook-satysfi-doc" {= "0.3.0"}
+
+  "satysfi-class-mdbook-satysfi" {= "0.3.0"}
+
+  "satysfi-class-stjarticle-doc" {= "1.3.2"}
+
+  "satysfi-class-stjarticle" {= "1.3.2"}
+
+  "satysfi-class-yabaitech-doc" {= "0.0.9"}
+
+  "satysfi-class-yabaitech" {= "0.0.9"}
+
+  "satysfi-code-printer-doc" {= "1.0.0"}
+
+  "satysfi-code-printer" {= "1.0.0"}
+
+  "satysfi-colorbox-doc" {= "0.1.1"}
+
+  "satysfi-colorbox" {= "0.1.1"}
+
+  "satysfi-csv-doc" {= "1.0.0"}
+
+  "satysfi-csv" {= "1.0.0"}
+
+  "satysfi-debug-show-value-doc" {= "0.1.2"}
+
+  "satysfi-debug-show-value" {= "0.1.2"}
+
+  "satysfi-derive" {= "1.0.0"}
+
+  "satysfi-easytable" {= "1.1.1"}
+
+  "satysfi-enumitem-doc" {= "3.0.1"}
+
+  "satysfi-enumitem" {= "3.0.1"}
+
+  "satysfi-fonts-asana-math-doc" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+
+  "satysfi-fonts-bodoni-star-doc" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-bodoni-star" {= "2.3+satysfi0.0.5"}
+
+  "satysfi-fonts-charis-sil-doc" {= "1.0.0"}
+
+  "satysfi-fonts-charis-sil" {= "1.0.0"}
+
+  "satysfi-fonts-computer-modern-unicode-doc" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}
+
+  "satysfi-fonts-cormorant-doc" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-cormorant" {= "3.601+satysfi0.0.5"}
+
+  "satysfi-fonts-dejavu-doc" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
+
+  "satysfi-fonts-han-sans-jp-doc" {= "2.003R"}
+
+  "satysfi-fonts-han-sans-jp" {= "2.003R"}
+
+  "satysfi-fonts-han-serif-jp-doc" {= "1.001R"}
+
+  "satysfi-fonts-han-serif-jp" {= "1.001R"}
+
+  "satysfi-fonts-inconsolata-doc" {= "3.001"}
+
+  "satysfi-fonts-inconsolata" {= "3.001"}
+
+  "satysfi-fonts-junicode-doc" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-junicode" {= "1.0002+satysfi0.0.5"}
+
+  "satysfi-fonts-noto-emoji-doc" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-emoji" {= "1.05+uh+2"}
+
+  "satysfi-fonts-noto-sans-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans-cjk-sc-doc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-cjk-sc" {= "2.001+1"}
+
+  "satysfi-fonts-noto-sans-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif-doc" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}
+
+  "satysfi-fonts-theano-doc" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fonts-theano" {= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
+
+  "satysfi-fss-doc" {= "0.2.0"}
+
+  "satysfi-fss-fontset-bodoni-star" {= "2.3"}
+
+  "satysfi-fss" {= "0.2.0"}
+
+  "satysfi-grcnum-doc" {= "0.2"}
+
+  "satysfi-grcnum" {= "0.2"}
+
+  "satysfi-image-doc" {= "0.1.0"}
+
+  "satysfi-image" {= "0.1.0"}
+
+  "satysfi-json-doc" {= "1.0.1"}
+
+  "satysfi-json" {= "1.0.1"}
+
+  "satysfi-karnaugh-doc" {= "0.0.1"}
+
+  "satysfi-karnaugh" {= "0.0.1"}
+
+  "satysfi-latexcmds-doc" {= "0.1.0"}
+
+  "satysfi-latexcmds" {= "0.1.0"}
+
+  "satysfi-lipsum-doc" {= "0.2.1"}
+
+  "satysfi-lipsum" {= "0.2.1"}
+
+  "satysfi-make-html-doc" {= "0.1.1"}
+
+  "satysfi-make-html" {= "0.1.1"}
+
+  "satysfi-make-latex-doc" {= "0.2.0"}
+
+  "satysfi-make-latex" {= "0.2.0"}
+
+  "satysfi-make-markdown" {= "0.1.0"}
+
+  "satysfi-matrixcd" {= "0.0.3"}
+
+  "satysfi-matrix-doc" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-matrix" {= "0.0.1+dev2019.10.15"}
+
+  "satysfi-md2latex-doc" {= "0.0.3"}
+
+  "satysfi-md2latex" {= "0.0.3"}
+
+  "satysfi-musikui-doc" {= "0.1.1"}
+
+  "satysfi-musikui" {= "0.1.1"}
+
+  "satysfi-ncsq-doc" {= "2.1.0"}
+
+  "satysfi-ncsq" {= "2.1.0"}
+
+  "satysfi-num-conversion-doc" {= "0.1.4"}
+
+  "satysfi-num-conversion" {= "0.1.4"}
+
+  "satysfi-pagenumber-doc" {= "1.0.0"}
+
+  "satysfi-pagenumber" {= "1.0.0"}
+
+  "satysfi-pagestyle-doc" {= "1.0.0"}
+
+  "satysfi-pagestyle" {= "1.0.0"}
+
+  "satysfi-parallel-doc" {= "0.1.0"}
+
+  "satysfi-parallel" {= "0.1.0"}
+
+  "satysfi-quotation-doc" {= "0.2.0"}
+
+  "satysfi-quotation" {= "0.2.0"}
+
+  "satysfi-railway-doc" {= "0.1.0"}
+
+  "satysfi-railway" {= "0.1.0"}
+
+  "satysfi-ruby-doc" {= "0.1.2"}
+
+  "satysfi-ruby" {= "0.1.2"}
+
+  "satysfi-simple-itemize-doc" {= "1.0.2"}
+
+  "satysfi-simple-itemize" {= "1.0.2"}
+
+  "satysfi-siunitx-doc" {= "0.1.1"}
+
+  "satysfi-siunitx" {= "0.1.1"}
+
+  "satysfi-test" {= "0.0.1"}
+
+  "satysfi-texlogo-doc" {= "0.1.1"}
+
+  "satysfi-texlogo" {= "0.1.1"}
+
+  "satysfi-tombo-doc" {= "0.2.0"}
+
+  "satysfi-tombo" {= "0.2.0"}
+
+  "satysfi-uline-doc" {= "0.2.2"}
+
+  "satysfi-uline" {= "0.2.2"}
+
+  "satysfi-xpath-doc" {= "0.2.0"}
+
+  "satysfi-xpath" {= "0.2.0"}
+
+  "satysfi-zrbase" {= "0.4.0"}
+
+# Package List End
+]


### PR DESCRIPTION
SATySFi 0.0.7 was released with https://github.com/gfngfn/SATySFi/pull/324

This PR adds it to the repo.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)