### PR TITLE
fix wrong dependency declaration of satysfi-num-conversion.0.1.1

### DIFF
--- a/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.1/opam
+++ b/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
 depends: [
   "satysfi" {>= "0.0.4+dev2020.02.22" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
-  "base" {>= "1.0.0"}
+  "satysfi-base" {>= "1.0.0" & < "2"}
 ]
 build: [ ]
 install: [


### PR DESCRIPTION
This should fix a build error found at https://github.com/na4zagin3/satyrographos-repo/pull/434:

```
+ opam exec -- satyrographos install
Reading runtime dist: /home/na4zagin3/Documents/Development/satysfi/satyrographos-repo/_opam/share/satysfi/dist
Read user libraries: ()
Reading opam libraries: (assert-eq assert-eq-doc bibyfi bibyfi-doc cancel class-exdesign
 class-exdesign-doc class-stjarticle class-stjarticle-doc debug-show-value
 debug-show-value-doc dist fonts-asana-math fonts-asana-math-doc
 fonts-computer-modern-unicode fonts-dejavu fonts-dejavu-doc fonts-noto-emoji
 fonts-noto-sans fonts-noto-sans-cjk-jp fonts-noto-sans-cjk-sc
 fonts-noto-sans-cjk-sc-doc fonts-noto-serif fonts-noto-serif-cjk-jp
 fonts-theano fonts-theano-doc grcnum grcnum-doc karnaugh karnaugh-doc lipsum
 lipsum-doc make-html make-html-doc make-markdown matrix matrix-doc musikui
 musikui-doc num-conversion ruby ruby-doc siunitx siunitx-doc uline uline-doc
 zrbase)
Overriding dist with user installed one
Uncaught exception:
  
  (Failure "Missing dependencies: (base)")

Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Satyrographos__CommandInstall.get_libraries in file "src/commandInstall.ml", line 116, characters 7-85
Called from Satyrographos__CommandInstall.install in file "src/commandInstall.ml", line 197, characters 20-66
Called from Core_kernel__Command.For_unix.run.(fun) in file "src/command.ml", line 2937, characters 8-205
Called from Base__Exn.handle_uncaught_aux in file "src/exn.ml", line 102, characters 6-10
```
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-develop--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- Add to snapshot `snapshot-stable-0-0-7`