### PR TITLE
Fix wrong satyrographos package name specified at satysfi-latexcmds-doc.0.1.0

### DIFF
--- a/packages/satysfi-latexcmds-doc/satysfi-latexcmds-doc.0.1.0/opam
+++ b/packages/satysfi-latexcmds-doc/satysfi-latexcmds-doc.0.1.0/opam
@@ -10,11 +10,11 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
-  "satysfi-latexcmds"
+  "satysfi-latexcmds" {= "%{version}%"}
 ]
 install: [
   ["satyrographos" "opam" "install"
-   "--name" "latexcmds"
+   "--name" "latexcmds-doc"
    "--prefix" "%{prefix}%"
    "--script" "%{build}%/Satyristes"]
 ]


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- Add to snapshot `snapshot-stable-0-0-7`