### PR TITLE
2 packages from monaqa/satysfi-easytable at 1.1.2

### DIFF
--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.2/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.8"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-easytable" {= "%{version}%"}
+  "satysfi-enumitem" {>= "3.0.0" & < "4.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "easytable-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.2.tar.gz"
+  checksum: [
+    "md5=43e16784e3b3b0219341e391c5fe7ca7"
+    "sha512=6289e13bfdef96f9512a0604bcc6b02aaa9291d14f0eba2c0dc1186822ccb652a77e8edcb4ab8ac8dc30615cdf88cb36a1653ac2c525065e1192a27ffd1930b9"
+  ]
+}
+
+

--- a/packages/satysfi-easytable/satysfi-easytable.1.1.2/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package to build simple tables"
+description: """A SATySFi package to build simple tables."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-easytable"
+bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
+
+depends: [
+  "satysfi" {>= "0.0.5" & < "0.0.8"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-base" {>= "1.4.0" & < "2.0.0"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "easytable"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/monaqa/satysfi-easytable/archive/v1.1.2.tar.gz"
+  checksum: [
+    "md5=43e16784e3b3b0219341e391c5fe7ca7"
+    "sha512=6289e13bfdef96f9512a0604bcc6b02aaa9291d14f0eba2c0dc1186822ccb652a77e8edcb4ab8ac8dc30615cdf88cb36a1653ac2c525065e1192a27ffd1930b9"
+  ]
+}
+


### PR DESCRIPTION
A SATySFi package to build simple tables

This pull-request concerns:
- `satysfi-easytable.1.1.2`
- `satysfi-easytable-doc.1.1.2`

---
* Homepage: https://github.com/monaqa/satysfi-easytable
* Source repo: git+https://github.com/monaqa/satysfi-easytable.git
* Bug tracker: https://github.com/monaqa/satysfi-easytable/issues
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-easytable-doc.1.1.2 satysfi-easytable.1.1.2
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-easytable-doc.1.1.2 satysfi-easytable.1.1.2
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-easytable-doc.1.1.2 satysfi-easytable.1.1.2