### PR TITLE
Workaround OPAM bug gh-5132

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -36,6 +36,7 @@ check_opam_integrity () {
 
 opam_install_dry_run () {
 	check_opam_integrity
+    # Workaround https://github.com/ocaml/opam/issues/5132
     mkdir -p "$TEMPORARY_WORK_DIR/opam"
     rsync -av "$(opam var prefix)/.opam-switch/install/" "$TEMPORARY_WORK_DIR/opam/install"
     opam install --dry-run "$@"


### PR DESCRIPTION
This commit workarounds https://github.com/ocaml/opam/issues/5132 by restoring `$(opam var prefix)/.opam-switch/install/` after running `opam install --dry-run`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- Add to snapshot `snapshot-stable-0-0-7`