### PR TITLE
Specify version lowerbound of satysfi-base

### DIFF
--- a/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"


### PR DESCRIPTION
satysfi-azmath.3.0.0 actually requires satysfi-base 1.4.0 or later.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- [ ] Add to snapshot `snapshot-develop--1` :: satysfi-azmath.0.0.3
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- [ ] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-azmath.0.0.3
- Add to snapshot `snapshot-stable-0-0-7`