### PR TITLE
Add revdep check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,11 +106,14 @@ jobs:
         run: |
           opam uninstall "$SNAPSHOT"
 
-      - name: Run script
+      - name: Build against snapshots and oldest deps
         run: |
-          # The issue may be solved by https://github.com/ocaml/opam/pull/5144
-          # Anyway, let me temporarily enable oldest-deps checks
-          # export SKIP_OLDEST_DEPS=1
+          export SKIP_REVERSE_DEPS=1
+          ./ci.sh
+
+      - name: Revdep tests
+        run: |
+          export SKIP_OLDEST_DEPS=1
           ./ci.sh
 
       - name: Test if the packages can be added to the snapshot

--- a/packages/satysfi-azmath/satysfi-azmath.0.0.1/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.6"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" & < "2"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.2/opam
@@ -7,9 +7,9 @@ bug-reports: "https://github.com/abenori/satysfi-class-jlreq/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-class-jlreq.git"
 license: "BSD-2-Clause-FreeBSD"
 depends: [
-  "satysfi" {>= "0.0.6"}
-  "satysfi-base" {>= "0.0.2"}
-  "satysfi-fss" {>= "0.0.2"}
+  "satysfi" {>= "0.0.6" & < "0.0.7"}
+  "satysfi-base" {>= "0.0.2" & < "1.5"}
+  "satysfi-fss" {>= "0.0.2" & < "0.3"}
   "satyrographos" {>= "0.0.2"}
 ]
 install: [

--- a/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.2.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
 
   # You may want to include the corresponding library
   "satysfi-class-mdbook-satysfi" {= "%{version}%"}
-  "satysfi-lipsum"
+  "satysfi-lipsum" { >= "0.2.0" }
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
 
   # You may want to include the corresponding library
   "satysfi-class-mdbook-satysfi" {= "%{version}%"}
-  "satysfi-lipsum"
+  "satysfi-lipsum" { >= "0.2.0" }
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.2.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.2.0/opam
@@ -17,16 +17,16 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable"
+  "satysfi-base" { >= "1.4.0" }
+  "satysfi-easytable" { >= "1.0.0" }
   "satysfi-quotation" { >="0.2.0" }
-  "satysfi-uline"
-  "satysfi-ruby"
-  "satysfi-fonts-noto-serif"
-  "satysfi-fonts-noto-serif-cjk-jp"
-  "satysfi-fonts-noto-sans"
-  "satysfi-fonts-noto-sans-cjk-jp"
-  "satysfi-fonts-dejavu"
+  "satysfi-uline" { >= "0.2.0" }
+  "satysfi-ruby" { >= "0.1.2" }
+  "satysfi-fonts-noto-serif" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-serif-cjk-jp" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-sans" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-sans-cjk-jp" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-dejavu" { >= "2.37+satysfi0.0.4" }
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
@@ -17,16 +17,16 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable"
+  "satysfi-base" { >= "1.4.0" }
+  "satysfi-easytable" { >= "1.0.0" }
   "satysfi-quotation" { >="0.2.0" }
-  "satysfi-uline"
-  "satysfi-ruby"
-  "satysfi-fonts-noto-serif"
-  "satysfi-fonts-noto-serif-cjk-jp"
-  "satysfi-fonts-noto-sans"
-  "satysfi-fonts-noto-sans-cjk-jp"
-  "satysfi-fonts-inconsolata"
+  "satysfi-uline" { >= "0.2.0" }
+  "satysfi-ruby" { >= "0.1.2" }
+  "satysfi-fonts-noto-serif" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-serif-cjk-jp" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-sans" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-noto-sans-cjk-jp" { >= "2.001+1+satysfi0.0.4" }
+  "satysfi-fonts-inconsolata" { >= "3.001" }
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-easytable/satysfi-easytable.1.0.0/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" & < "2"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.1/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.1/opam
@@ -18,8 +18,8 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-base" {>= "1.4.0" & < "2"}
+  "satysfi-easytable" {>= "1.0.0" & < "2"}
   "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.2/opam
@@ -18,8 +18,8 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-base" {>= "1.4.0" & < "2"}
+  "satysfi-easytable" {>= "1.0.0" & < "2"}
   "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.3/opam
@@ -18,8 +18,8 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable" {>= "1.0.0"}
+  "satysfi-base" {>= "1.4.0" & < "2"}
+  "satysfi-easytable" {>= "1.0.0" & < "2"}
   "satysfi-enumitem" {>= "2.0.0" & < "3.0.0"}
 ]
 build: [

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
@@ -18,8 +18,8 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base"
-  "satysfi-easytable" {>= "1.0.0" & < "2.0" }
+  "satysfi-base" {>= "1.4.0"}
+  "satysfi-easytable" {>= "1.0.0" & < "2"}
   "satysfi-enumitem" {>= "3.0.0" & < "4.0" }
 ]
 build: [

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.1/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" & < "2"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.2/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.2/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" & < "2"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.3/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.3/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0" & < "2"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-json-doc/satysfi-json-doc.1.0.1/opam
+++ b/packages/satysfi-json-doc/satysfi-json-doc.1.0.1/opam
@@ -18,7 +18,7 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/packages/satysfi-json/satysfi-json.1.0.1/opam
+++ b/packages/satysfi-json/satysfi-json.1.0.1/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base"
+  "satysfi-base" {>= "1.4.0"}
 ]
 build: [
   ["satyrographos" "opam" "build"


### PR DESCRIPTION
This PR adds revdep check and fix wrong dependency declarations on satysfi-base.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-develop--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- Add to snapshot `snapshot-stable-0-0-7`