### PR TITLE
Fix wrong dependencies of satysfi-cancel.0.0.1 and satysfi-class-stjarticle.1.3.2

### DIFF
--- a/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
+++ b/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
@@ -10,8 +10,8 @@ homepage: "https://github.com/yuhr/satysfi-cancel"
 bug-reports: "https://github.com/yuhr/satysfi-cancel/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-cancel.git"
 depends: [
-  "satysfi"
-  "satyrographos"
+  "satysfi" {>= "0.0.3" & < "0.0.8"}
+  "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
   "satysfi-dist"
 ]
 install: [

--- a/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
   "satysfi" { >= "0.0.3" & < "0.0.8" }
-  "satyrographos" {>= "0.0.1" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 install: [
   ["satyrographos" "opam" "install"


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)