### PR TITLE
2 packages from pickoba/satysfi-algorithm at 1.0.0

### DIFF
--- a/packages/satysfi-algorithm-doc/satysfi-algorithm-doc.1.0.0/opam
+++ b/packages/satysfi-algorithm-doc/satysfi-algorithm-doc.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Document of satysfi-algorithm"
+description: """
+Document of satysfi-algorithm.
+"""
+maintainer: "KOBAYASHI Ryota <koba.pic@gmail.com>"
+authors: "KOBAYASHI Ryota <koba.pic@gmail.com>"
+license: "MIT" # Choose what you want
+homepage: "https://github.com/pickoba/satysfi-algorithm"
+dev-repo: "git+https://github.com/pickoba/satysfi-algorithm.git"
+bug-reports: "https://github.com/pickoba/satysfi-algorithm/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-algorithm" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
+  "satysfi-fss" { >= "0.2.0" & < "0.3.0" }
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "algorithm-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "algorithm-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/pickoba/satysfi-algorithm/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=a7566dab997b947afc45c1fb25147945"
+    "sha512=9c25bb889d85993a6b1cd4287bfbfef538abaeedcff1b00cfc14350cbf28316e9617d9e660b23cda5bf81b3f9d2a686cf53f54a7d0a37c712bea4197c7b46bf1"
+  ]
+}

--- a/packages/satysfi-algorithm/satysfi-algorithm.1.0.0/opam
+++ b/packages/satysfi-algorithm/satysfi-algorithm.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Typesetting algorithms in pseudo-code"
+description: """
+Typesetting algorithms in pseudo-code. It is the equivalent of the algorithmicx package in LaTeX.
+"""
+maintainer: "KOBAYASHI Ryota <koba.pic@gmail.com>"
+authors: "KOBAYASHI Ryota <koba.pic@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/pickoba/satysfi-algorithm"
+dev-repo: "git+https://github.com/pickoba/satysfi-algorithm.git"
+bug-reports: "https://github.com/pickoba/satysfi-algorithm/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # If your library depends on other libraries, please write down here
+  "satysfi-dist"
+  "satysfi-base" { >= "1.4.0" & < "2.0.0" }
+  "satysfi-fss" { >= "0.2.0" & < "0.3.0" }
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "algorithm"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "algorithm"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/pickoba/satysfi-algorithm/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=a7566dab997b947afc45c1fb25147945"
+    "sha512=9c25bb889d85993a6b1cd4287bfbfef538abaeedcff1b00cfc14350cbf28316e9617d9e660b23cda5bf81b3f9d2a686cf53f54a7d0a37c712bea4197c7b46bf1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:

- `satysfi-algorithm.1.0.0` : Typesetting pseudo-code in SATySFi
- `satysfi-algorithm-doc.1.0.0` : Document for satysfi-algorithm

---

Homepage: https://github.com/pickoba/satysfi-algorithm
Source repo: git+https://github.com/pickoba/satysfi-algorithm.git
Bug tracker: https://github.com/pickoba/satysfi-algorithm/issues
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [ ] Add to snapshot `snapshot-develop` :: satysfi-algorithm-doc.1.0.0 satysfi-algorithm.1.0.0
- [ ] Add to snapshot `snapshot-develop--1` :: satysfi-algorithm-doc.1.0.0 satysfi-algorithm.1.0.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [ ] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-algorithm-doc.1.0.0 satysfi-algorithm.1.0.0
- [ ] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-algorithm-doc.1.0.0 satysfi-algorithm.1.0.0
- [ ] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-algorithm-doc.1.0.0 satysfi-algorithm.1.0.0