### PR TITLE
Ignore comment files when pull-number is empty

### DIFF
--- a/.github/workflows/ci-comment.yaml
+++ b/.github/workflows/ci-comment.yaml
@@ -50,7 +50,10 @@ jobs:
           for file in *.zip ; do
             unzip "$file" -d "${file%.zip}"
           done
-          ls -lR
+          for f in pr-*/comment.txt ; do
+            echo "# $f"
+            cat "$f"
+          done
 
       - name: Update the PR body
         uses: actions/github-script@v2
@@ -74,6 +77,9 @@ jobs:
             for await (const dirent of dir) {
               if (dirent.isDirectory() && dirent.name.startsWith('pr-')) {
                   const dirname = dirent.name;
+                  if (!fs.existsSync(`${dirname}/pull-number.txt)) {
+                    continue;
+                  }
                   const pull_number = Number(fs.readFileSync(`${dirname}/pull-number.txt`, 'utf8'));
                   const run_id = Number(fs.readFileSync(`${dirname}/run-id.txt`, 'utf8'));
                   const snapshot = fs.readFileSync(`${dirname}/id.txt`, 'utf8').trim();


### PR DESCRIPTION
The artifacts for CI Comment lacks pull-number.txt and other mandatory files sometimes.

https://github.com/na4zagin3/satyrographos-repo/runs/6544416224?check_suite_focus=true
```
Archive:  pr-248617550.zip
  inflating: pr-248617550/comment.txt  
Archive:  pr-248617551.zip
  inflating: pr-248617551/comment.txt  
Archive:  pr-248617552.zip
  inflating: pr-248617552/comment.txt  
Archive:  pr-248617553.zip
  inflating: pr-248617553/comment.txt  
```
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)