### PR TITLE
2 packages from abenori/satysfi-matrixcd at 0.1.0

### DIFF
--- a/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
+++ b/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
@@ -9,8 +9,8 @@ dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
   "satysfi" {>= "0.0.6" & < "0.0.8"}
-  "satysfi-base" {>= "1.3.0" & < "1.5.0"}
-  "satyrographos" {>= "0.0.2.0" & < "0.0.3.0"}
+  "satysfi-base" {>= "1.3.0" & < "1.5"}
+  "satyrographos" {>= "0.0.2.0" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-matrixcd" {= "%{version}%"}
 ]

--- a/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
+++ b/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of MatrixCD"
+description: """Document of MatrixCD package"""
+authors: "Noriyuki Abe"
+maintainer: "Noriyuki Abe"
+homepage: "https://github.com/abenori/satysfi-matrixcd/"
+bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
+dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
+license: "MIT"
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi-base" {>= "1.3.0" & < "1.5.0"}
+  "satyrographos" {>= "0.0.2.0" & < "0.0.3.0"}
+  "satysfi-dist"
+  "satysfi-matrixcd" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "matrixcd-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "matrixcd-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-matrixcd/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=5e013e5e323c28e2b88c673deaaf4a26"
+    "sha512=efe63e475bc51fb966c7cabaa9bf724a855e34e4014f34cd88752927cdbc222889f6cb9d41fe76d1c05438f315e9a73c4e36ff67b0943d2cfa1e133cf90e7857"
+  ]
+}

--- a/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
+++ b/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A package for SATySFi to draw commutative diagrams"
+description: """A package for SATySFi to draw commutative diagrams"""
+authors: "Noriyuki Abe"
+maintainer: "Noriyuki Abe"
+homepage: "https://github.com/abenori/satysfi-matrixcd/"
+bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
+dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
+license: "MIT"
+depends: [
+  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi-base" {>= "1.3.0" & < "1.5.0"}
+  "satyrographos" {>= "0.0.2.0" & < "0.0.3.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "matrixcd"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "matrixcd"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src: "https://github.com/abenori/satysfi-matrixcd/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=5e013e5e323c28e2b88c673deaaf4a26"
+    "sha512=efe63e475bc51fb966c7cabaa9bf724a855e34e4014f34cd88752927cdbc222889f6cb9d41fe76d1c05438f315e9a73c4e36ff67b0943d2cfa1e133cf90e7857"
+  ]
+}

--- a/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
+++ b/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
@@ -9,8 +9,9 @@ dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
   "satysfi" {>= "0.0.6" & < "0.0.8"}
-  "satysfi-base" {>= "1.3.0" & < "1.5.0"}
-  "satyrographos" {>= "0.0.2.0" & < "0.0.3.0"}
+  "satysfi-dist"
+  "satysfi-base" {>= "1.3.0" & < "1.5"}
+  "satyrographos" {>= "0.0.2.0" & < "0.0.3"}
 ]
 build: [
   ["satyrographos" "opam" "build"


### PR DESCRIPTION
This is a pull request for package updates.  As I meat an error with opam publish, I do it manually.

This pull-request concerns:
-satysfi-matrixcd.0.1.0
-satysfi-matrixcd-doc.0.1.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-matrixcd-doc.0.1.0 satysfi-matrixcd.0.1.0
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-matrixcd-doc.0.1.0 satysfi-matrixcd.0.1.0
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-matrixcd-doc.0.1.0 satysfi-matrixcd.0.1.0
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-matrixcd-doc.0.1.0 satysfi-matrixcd.0.1.0
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-matrixcd-doc.0.1.0 satysfi-matrixcd.0.1.0