### PR TITLE
Update dependency of satysfi-chemfml

### DIFF
--- a/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
+++ b/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/gw31415/satysfi-chemfml"
 dev-repo: "git+https://github.com/gw31415/satysfi-chemfml.git"
 bug-reports: "https://github.com/gw31415/satysfi-chemfml/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.7" }
+  "satysfi" { >= "0.0.6" & < "0.0.8" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here


### PR DESCRIPTION
satysfi-chemfml supports SATySFi 0.0.7
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-chemfml.1.0.1
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-chemfml.1.0.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-chemfml.1.0.1
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-chemfml.1.0.1
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-chemfml.1.0.1