### PR TITLE
2 packages from monaqa/satysfi-fonts-material-icons at 1.0.1

### DIFF
--- a/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Docs for SATySFi Font Package for Google Material Icons"
+description: """
+Docs for SATySFi Font Package for Google Material Icons
+"""
+maintainer: "Mogami Shinichi <cmonaqa@gmail.com>"
+authors: "Mogami Shinichi <cmonaqa@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/monaqa/satysfi-fonts-material-icons"
+dev-repo: "git+https://github.com/monaqa/satysfi-fonts-material-icons.git"
+bug-reports: "https://github.com/monaqa/satysfi-fonts-material-icons/issues"
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  # You may want to include the corresponding library
+  "satysfi-fonts-material-icons" {= "%{version}%"}
+
+  # Other libraries
+  "satysfi-dist"
+  "satysfi-base" {>= "1.0.0" &  < "2.0.0"}
+  "satysfi-easytable" {>= "1.1.2" & < "2.0.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-material-icons-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-material-icons-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/monaqa/satysfi-fonts-material-icons/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=aedb1343ca76560dd090b25372ee3bdb"
+    "sha512=7d328c5e3419592f84f2def740f3fc096926dee8044d17ae7e0312dff274d810d89dff8224e078e7cf8e6d69a74d9d3bce79a203ed8caaa9a5e92a6e348bd635"
+  ]
+}

--- a/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Google Material Icons"
+description: """
+SATySFi Font Package for Google Material Icons
+"""
+maintainer: "Mogami Shinichi <cmonaqa@gmail.com>"
+authors: "Mogami Shinichi <cmonaqa@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/monaqa/satysfi-fonts-material-icons"
+dev-repo: "git+https://github.com/monaqa/satysfi-fonts-material-icons.git"
+bug-reports: "https://github.com/monaqa/satysfi-fonts-material-icons/issues"
+
+extra-source "MaterialIconsOutlined-Regular.otf" {
+  src: "https://github.com/google/material-design-icons/raw/9a68a7b2aa5131c31afd822fa796322754802bfb/font/MaterialIconsOutlined-Regular.otf"
+  checksum: [
+    "sha256=c637b3d3ffb9e2b91b9edc0f0cff8c5d9a28f5db06407cf89ead441d2eb04803"
+  ]
+}
+extra-source "MaterialIconsRound-Regular.otf" {
+  src: "https://github.com/google/material-design-icons/raw/9a68a7b2aa5131c31afd822fa796322754802bfb/font/MaterialIconsRound-Regular.otf"
+  checksum: [
+    "sha256=60f2cf8ac4e72e30456d7bde1fb5f7096655c2aee6fbd6b4bd8f81e7d6b3bcda"
+  ]
+}
+extra-source "MaterialIconsSharp-Regular.otf" {
+  src: "https://github.com/google/material-design-icons/raw/9a68a7b2aa5131c31afd822fa796322754802bfb/font/MaterialIconsSharp-Regular.otf"
+  checksum: [
+    "sha256=8b452267718b45e8c5cdaa0a90c8b7baaa199c876b8d497c8a7010a7cec49197"
+  ]
+}
+extra-source "MaterialIconsTwoTone-Regular.otf" {
+  src: "https://github.com/google/material-design-icons/raw/9a68a7b2aa5131c31afd822fa796322754802bfb/font/MaterialIconsTwoTone-Regular.otf"
+  checksum: [
+    "sha256=119f04df891fee7b8c441361c4e9370bacd69188b7d8b9d4f4b4dc90d2f4cf5f"
+  ]
+}
+
+depends: [
+  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-material-icons"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/monaqa/satysfi-fonts-material-icons/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=aedb1343ca76560dd090b25372ee3bdb"
+    "sha512=7d328c5e3419592f84f2def740f3fc096926dee8044d17ae7e0312dff274d810d89dff8224e078e7cf8e6d69a74d9d3bce79a203ed8caaa9a5e92a6e348bd635"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`satysfi-fonts-material-icons.1.0.1`: SATySFi Font Package for Google Material Icons
-`satysfi-fonts-material-icons-doc.1.0.1`: Docs for SATySFi Font Package for Google Material Icons

---
* Homepage: https://github.com/monaqa/satysfi-fonts-material-icons
* Source repo: git+https://github.com/monaqa/satysfi-fonts-material-icons.git
* Bug tracker: https://github.com/monaqa/satysfi-fonts-material-icons/issues
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-develop--1` :: satysfi-fonts-material-icons-doc.1.0.1 satysfi-fonts-material-icons.1.0.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-fonts-material-icons-doc.1.0.1 satysfi-fonts-material-icons.1.0.1
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-fonts-material-icons-doc.1.0.1 satysfi-fonts-material-icons.1.0.1