### PR TITLE
Include SATySFi and Satyrographos in the oldest dep test

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -85,7 +85,7 @@ opam_install_dry_run () {
 }
 
 install_oldest_deps () {
-    opam install opam-0install && opam install $(opam exec -- opam-0install --prefer-oldest "$@" | tr ' ' '\n' | sed -n -e '/^satyrographos$/p' -e '/^satysfi$/p' -e '/^satysfi-/p')
+    opam install opam-0install && opam install $(opam exec -- opam-0install --prefer-oldest "$@" | tr ' ' '\n' | sed -n -e '/^satyrographos\./p' -e '/^satysfi\./p' -e '/^satysfi-/p')
 }
 
 check_reverse_deps () {


### PR DESCRIPTION
SATySFi and Satyrographos were mistakenly excluded from oldest-dep test.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-develop--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)