### PR TITLE
Fetch submodule during CI

### DIFF
--- a/.github/workflows/ci-comment.yaml
+++ b/.github/workflows/ci-comment.yaml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Checkout code (10 commits)
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 10
+          submodules: true
 
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 10
+          submodules: true
 
       - name: Fetch master branch (50 commits)
         run: |

--- a/.github/workflows/pr-followup.yaml
+++ b/.github/workflows/pr-followup.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
 
       - uses: tibdex/github-app-token@v1
         id: generate-token

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 10
+          submodules: true
 
       - name: List up snapshots
         id: snapshots

--- a/.github/workflows/update-develop.yaml
+++ b/.github/workflows/update-develop.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
 
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
This PR specifies `submodules: true` input for `actions/checkout@v2` action.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)