### PR TITLE
Update upper version restriction for satysfi: A

### DIFF
--- a/packages/satysfi-algorithm-doc/satysfi-algorithm-doc.1.0.0/opam
+++ b/packages/satysfi-algorithm-doc/satysfi-algorithm-doc.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/pickoba/satysfi-algorithm"
 dev-repo: "git+https://github.com/pickoba/satysfi-algorithm.git"
 bug-reports: "https://github.com/pickoba/satysfi-algorithm/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-algorithm/satysfi-algorithm.1.0.0/opam
+++ b/packages/satysfi-algorithm/satysfi-algorithm.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/pickoba/satysfi-algorithm"
 dev-repo: "git+https://github.com/pickoba/satysfi-algorithm.git"
 bug-reports: "https://github.com/pickoba/satysfi-algorithm/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
+++ b/packages/satysfi-arrows-doc/satysfi-arrows-doc.0.1.0/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/uemurax/satysfi-arrows"
 bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
 depends: [
-  "satysfi" { >= "0.0.5+dev2020.09.05" & < "0.0.8" }
+  "satysfi" { >= "0.0.5+dev2020.09.05" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-arrows" {= "%{version}%"}

--- a/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
+++ b/packages/satysfi-arrows/satysfi-arrows.0.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/uemurax/satysfi-arrows"
 bug-reports: "https://github.com/uemurax/satysfi-arrows/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-arrows.git"
 depends: [
-  "satysfi" { >= "0.0.5+dev2020.09.05" & < "0.0.8" }
+  "satysfi" { >= "0.0.5+dev2020.09.05" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>= "1.3"}

--- a/packages/satysfi-assert-eq-doc/satysfi-assert-eq-doc.0.1.2/opam
+++ b/packages/satysfi-assert-eq-doc/satysfi-assert-eq-doc.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-assert-eq/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-assert-eq.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 

--- a/packages/satysfi-assert-eq/satysfi-assert-eq.0.1.2/opam
+++ b/packages/satysfi-assert-eq/satysfi-assert-eq.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-assert-eq/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-assert-eq.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]

--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-azmath" {= "%{version}%"}

--- a/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
+++ b/packages/satysfi-azmath/satysfi-azmath.0.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>= "1.4.0"}

--- a/packages/satysfi-base/satysfi-base.1.5.0/opam
+++ b/packages/satysfi-base/satysfi-base.1.5.0/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/nyuichi/satysfi-base"
 bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
 dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.8"}
+  "satysfi" {>= "0.0.5" & < "0.1"}
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-fonts-dejavu" {>= "2.37"}

--- a/packages/satysfi-json-doc/satysfi-json-doc.1.1.3/opam
+++ b/packages/satysfi-json-doc/satysfi-json-doc.1.1.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-json"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-json.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-json/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-json/satysfi-json.1.1.3/opam
+++ b/packages/satysfi-json/satysfi-json.1.1.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-json"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-json.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-json/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here


### PR DESCRIPTION
This PR split from #504.  This updates version restriction on satysfi for packages that start with `a`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (Inconsistent)