### PR TITLE
Update upper version restriction for satysfi

### DIFF
--- a/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
+++ b/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/yuhr/satysfi-cancel"
 bug-reports: "https://github.com/yuhr/satysfi-cancel/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-cancel.git"
 depends: [
-  "satysfi" {>= "0.0.3" & < "0.0.8"}
+  "satysfi" {>= "0.0.3" & < "0.1"}
   "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-chemfml-doc/satysfi-chemfml-doc.1.0.1/opam
+++ b/packages/satysfi-chemfml-doc/satysfi-chemfml-doc.1.0.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/gw31415/satysfi-chemfml"
 dev-repo: "git+https://github.com/gw31415/satysfi-chemfml.git"
 bug-reports: "https://github.com/gw31415/satysfi-chemfml/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
+++ b/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/gw31415/satysfi-chemfml"
 dev-repo: "git+https://github.com/gw31415/satysfi-chemfml.git"
 bug-reports: "https://github.com/gw31415/satysfi-chemfml/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-class-cv-doc/satysfi-class-cv-doc.0.1.0/opam
+++ b/packages/satysfi-class-cv-doc/satysfi-class-cv-doc.0.1.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/MasWag/cv-satysfi/issues"
 dev-repo: "git+https://github.com/MasWag/cv-satysfi.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-class-cv/satysfi-class-cv.0.1.0/opam
+++ b/packages/satysfi-class-cv/satysfi-class-cv.0.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/MasWag/cv-satysfi"
 bug-reports: "https://github.com/MasWag/cv-satysfi/issues"
 dev-repo: "git+https://github.com/MasWag/cv-satysfi.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-base" {>= "1.2.1" & < "2.0"}
   "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}

--- a/packages/satysfi-class-exdesign-doc/satysfi-class-exdesign-doc.0.3.1/opam
+++ b/packages/satysfi-class-exdesign-doc/satysfi-class-exdesign-doc.0.3.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/exdesign/issues"
 dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 

--- a/packages/satysfi-class-exdesign/satysfi-class-exdesign.0.3.1/opam
+++ b/packages/satysfi-class-exdesign/satysfi-class-exdesign.0.3.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/exdesign/issues"
 dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/abenori/satysfi-class-jlreq/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-class-jlreq.git"
 license: "BSD-2-Clause-FreeBSD"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satysfi-fss" {>= "0.0.2" & < "0.3.0"}
   "satyrographos" {>= "0.0.2" & < "0.0.3.0"}

--- a/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-class-mdbook-satysfi.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-class-mdbook-satysfi.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/slydifi/issues"
 dev-repo: "git+https://github.com/monaqa/slydifi.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-slydifi" {= "%{version}%"}
   "satysfi-easytable" {>= "1.0.0" & < "2.0"}

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/slydifi/issues"
 dev-repo: "git+https://github.com/monaqa/slydifi.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-enumitem" {>= "3.0.1" & < "4.0"}
   "satysfi-figbox" {>= "0.1.3" & < "0.2.0"}

--- a/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/stjarticle"
 bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-stjarticle" {= "1.3.2"}

--- a/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/stjarticle"
 bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.9/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.9/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
 bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
 dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-class-yabaitech" {= "0.0.9"}
 ]

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.9/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.9/opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
 bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
 dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-base" {>= "1.2.1" & < "2.0.0"}
   "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.1.1/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.1.1/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.8" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-code-printer" {= "%{version}%"}
   "satysfi-dist"

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.1.1/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.1.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.8" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-base" { >= "1.4.0" & < "2.0" }

--- a/packages/satysfi-csv-doc/satysfi-csv-doc.1.0.0/opam
+++ b/packages/satysfi-csv-doc/satysfi-csv-doc.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-csv"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-csv.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-csv/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   "satysfi-csv" {= "%{version}%"}

--- a/packages/satysfi-csv/satysfi-csv.1.0.0/opam
+++ b/packages/satysfi-csv/satysfi-csv.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-csv"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-csv.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-csv/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   "satysfi-dist"

--- a/packages/satysfi-csvtable-doc/satysfi-csvtable-doc.1.1.0/opam
+++ b/packages/satysfi-csvtable-doc/satysfi-csvtable-doc.1.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/qwjyh/satysfi-csvtable"
 dev-repo: "git+https://github.com/qwjyh/satysfi-csvtable.git"
 bug-reports: "https://github.com/qwjyh/satysfi-csvtable/issues"
 depends: [
-  "satysfi" { >= "0.0.7" & < "0.0.8" }
+  "satysfi" { >= "0.0.7" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-csvtable/satysfi-csvtable.1.1.0/opam
+++ b/packages/satysfi-csvtable/satysfi-csvtable.1.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/qwjyh/satysfi-csvtable"
 dev-repo: "git+https://github.com/qwjyh/satysfi-csvtable.git"
 bug-reports: "https://github.com/qwjyh/satysfi-csvtable/issues"
 depends: [
-  "satysfi" { >= "0.0.7" & < "0.0.8" }
+  "satysfi" { >= "0.0.7" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-figbox"
 dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
 bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-figbox"
 dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
 bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.958+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.958+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.958+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.958+1+satysfi0.0.4/opam
@@ -25,7 +25,7 @@ extra-source "Asana-Math.otf" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-bodoni-star.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-bodoni-star" {= "%{version}%"}

--- a/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "Bodoni-master.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/yuhr/satysfi-fonts-charis-sil"
 bug-reports: "https://github.com/yuhr/satysfi-fonts-charis-sil/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-fonts-charis-sil.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-fonts-charis-sil" {= "%{version}%"}
   "satysfi-dist"

--- a/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
@@ -19,7 +19,7 @@ extra-source "CharisSIL-5.000.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 build: [

--- a/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}

--- a/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "computer-modern-unicode.tar.xz" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-cormorant"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-cormorant/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-cormorant.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-cormorant" {= "%{version}%"}

--- a/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "Cormorant_Install_v3.601.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.37+satysfi0.0.4/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-dejavu"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-dejavu/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-dejavu.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
 ]

--- a/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37+satysfi0.0.4/opam
@@ -18,7 +18,7 @@ extra-source "dejavu-fonts-ttf-2.37.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-han-sans-jp" { = "%{version}%" }

--- a/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
@@ -19,7 +19,7 @@ extra-source "SourceHanSansJP.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-han-serif-jp-doc/satysfi-fonts-han-serif-jp-doc.1.001R/opam
+++ b/packages/satysfi-fonts-han-serif-jp-doc/satysfi-fonts-han-serif-jp-doc.1.001R/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-han-serif-jp" { = "%{version}%" }

--- a/packages/satysfi-fonts-han-serif-jp/satysfi-fonts-han-serif-jp.1.001R/opam
+++ b/packages/satysfi-fonts-han-serif-jp/satysfi-fonts-han-serif-jp.1.001R/opam
@@ -19,7 +19,7 @@ extra-source "SourceHanSerifJP.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-ibm-plex-sans-jp-doc/satysfi-fonts-ibm-plex-sans-jp-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-ibm-plex-sans-jp-doc/satysfi-fonts-ibm-plex-sans-jp-doc.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp"
 dev-repo: "git+https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp.git"
 bug-reports: "https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-fonts-ibm-plex-sans-jp/satysfi-fonts-ibm-plex-sans-jp.1.0.0/opam
+++ b/packages/satysfi-fonts-ibm-plex-sans-jp/satysfi-fonts-ibm-plex-sans-jp.1.0.0/opam
@@ -17,7 +17,7 @@ extra-source "OpenType.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 build: [

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-dist"

--- a/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
@@ -19,7 +19,7 @@ extra-source "inconsolata.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-junicode"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-junicode/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-junicode.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-junicode" {= "%{version}%"}

--- a/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "junicode-1.002.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-fonts-material-icons"
 dev-repo: "git+https://github.com/monaqa/satysfi-fonts-material-icons.git"
 bug-reports: "https://github.com/monaqa/satysfi-fonts-material-icons/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
@@ -36,7 +36,7 @@ extra-source "MaterialIconsTwoTone-Regular.otf" {
 }
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 install: [

--- a/packages/satysfi-fonts-noto-emoji-doc/satysfi-fonts-noto-emoji-doc.1.05+uh+2/opam
+++ b/packages/satysfi-fonts-noto-emoji-doc/satysfi-fonts-noto-emoji-doc.1.05+uh+2/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-emoji"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-emoji/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-emoji.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-emoji" {>= "1.05+uh+2"}

--- a/packages/satysfi-fonts-noto-emoji/satysfi-fonts-noto-emoji.1.05+uh+2/opam
+++ b/packages/satysfi-fonts-noto-emoji/satysfi-fonts-noto-emoji.1.05+uh+2/opam
@@ -23,7 +23,7 @@ extra-source "noto-emoji-2019-11-19-unicode12.zip" {
 
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans-cjk-jp.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-noto-sans-cjk-sc" {= "%{version}%"}
 ]

--- a/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans-cjk-sc.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-doc/satysfi-fonts-noto-sans-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-doc/satysfi-fonts-noto-sans-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-sans/satysfi-fonts-noto-sans.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans/satysfi-fonts-noto-sans.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-serif-cjk-jp.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-serif-doc/satysfi-fonts-noto-serif-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-doc/satysfi-fonts-noto-serif-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-serif/satysfi-fonts-noto-serif.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif/satysfi-fonts-noto-serif.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-serif.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-theano-doc/satysfi-fonts-theano-doc.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
+++ b/packages/satysfi-fonts-theano-doc/satysfi-fonts-theano-doc.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-theano"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-theano/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-theano.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-theano"

--- a/packages/satysfi-fonts-theano/satysfi-fonts-theano.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
+++ b/packages/satysfi-fonts-theano/satysfi-fonts-theano.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
@@ -19,7 +19,7 @@ extra-source "theano-2.0.otf.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fss-doc/satysfi-fss-doc.0.2.0/opam
+++ b/packages/satysfi-fss-doc/satysfi-fss-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 

--- a/packages/satysfi-fss-fontset-bodoni-star/satysfi-fss-fontset-bodoni-star.2.3/opam
+++ b/packages/satysfi-fss-fontset-bodoni-star/satysfi-fss-fontset-bodoni-star.2.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 
   "satysfi-fss" {>= "0.2.0" & < "0.3.0"}

--- a/packages/satysfi-fss/satysfi-fss.0.2.0/opam
+++ b/packages/satysfi-fss/satysfi-fss.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 

--- a/packages/satysfi-make-html-doc/satysfi-make-html-doc.0.1.1/opam
+++ b/packages/satysfi-make-html-doc/satysfi-make-html-doc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-html/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-html.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-make-html" {= "%{version}%"}

--- a/packages/satysfi-make-html/satysfi-make-html.0.1.1/opam
+++ b/packages/satysfi-make-html/satysfi-make-html.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-html/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-html.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
+++ b/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-make-latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-make-latex" {= "%{version}%"}

--- a/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
+++ b/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
+++ b/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-markdown/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-markdown.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]

--- a/packages/satysfi-matrix-doc/satysfi-matrix-doc.0.0.1+dev2019.10.15/opam
+++ b/packages/satysfi-matrix-doc/satysfi-matrix-doc.0.0.1+dev2019.10.15/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/nekketsuuu/satysfi-matrix"
 bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
 dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-matrix" {= "%{version}%"}
 ]

--- a/packages/satysfi-matrix/satysfi-matrix.0.0.1+dev2019.10.15/opam
+++ b/packages/satysfi-matrix/satysfi-matrix.0.0.1+dev2019.10.15/opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/nekketsuuu/satysfi-matrix"
 bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
 dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [ ]

--- a/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
+++ b/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
-  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi" {>= "0.0.6" & < "0.1"}
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satyrographos" {>= "0.0.2.0" & < "0.0.3"}
   "satysfi-dist"

--- a/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
+++ b/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
-  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi" {>= "0.0.6" & < "0.1"}
   "satysfi-dist"
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satyrographos" {>= "0.0.2.0" & < "0.0.3"}

--- a/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
+++ b/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-md2latex" {= "%{version}%"}

--- a/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
+++ b/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-make-latex" {>= "0.2.0" & < "0.3.0"}

--- a/packages/satysfi-musikui-doc/satysfi-musikui-doc.0.1.1/opam
+++ b/packages/satysfi-musikui-doc/satysfi-musikui-doc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/musikui.satyh/issues"
 dev-repo: "git+https://github.com/puripuri2100/musikui.satyh.git"
 
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-musikui" {= "%{version}%"}

--- a/packages/satysfi-musikui/satysfi-musikui.0.1.1/opam
+++ b/packages/satysfi-musikui/satysfi-musikui.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/musikui.satyh/issues"
 dev-repo: "git+https://github.com/puripuri2100/musikui.satyh.git"
 
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `c`, `f`, or `m`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- Add to snapshot `snapshot-develop`
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`
- Add to snapshot `snapshot-stable-0-0-6--1`
- Add to snapshot `snapshot-stable-0-0-7`