### PR TITLE
Update upper version restriction for satysfi: B and C

### DIFF
--- a/packages/satysfi-bibyfi-doc/satysfi-bibyfi-doc.0.0.2/opam
+++ b/packages/satysfi-bibyfi-doc/satysfi-bibyfi-doc.0.0.2/opam
@@ -5,7 +5,7 @@ authors: ["Nakano Masaki<namachan10777@gmail.com>" "T. Suwa"]
 homepage: "https://github.com/namachan10777/BiByFi"
 bug-reports: "https://github.com/namachan10777/BiByFi/issues"
 depends: [
-  "satysfi" { >= "0.0.4+dev2020.04.25" & < "0.0.8" }
+  "satysfi" { >= "0.0.4+dev2020.04.25" & < "0.1" }
   "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-bibyfi" {= "%{version}%"}

--- a/packages/satysfi-bibyfi/satysfi-bibyfi.0.0.2/opam
+++ b/packages/satysfi-bibyfi/satysfi-bibyfi.0.0.2/opam
@@ -12,7 +12,7 @@ license: "Unlicense"
 homepage: "https://github.com/namachan10777/BiByFi"
 bug-reports: "https://github.com/namachan10777/BiByFi/issues"
 depends: [
-  "satysfi" { >= "0.0.4+dev2020.04.25" & < "0.0.8" }
+  "satysfi" { >= "0.0.4+dev2020.04.25" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
 ]

--- a/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
+++ b/packages/satysfi-cancel/satysfi-cancel.0.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/yuhr/satysfi-cancel"
 bug-reports: "https://github.com/yuhr/satysfi-cancel/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-cancel.git"
 depends: [
-  "satysfi" {>= "0.0.3" & < "0.0.8"}
+  "satysfi" {>= "0.0.3" & < "0.1"}
   "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-chemfml-doc/satysfi-chemfml-doc.1.0.1/opam
+++ b/packages/satysfi-chemfml-doc/satysfi-chemfml-doc.1.0.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/gw31415/satysfi-chemfml"
 dev-repo: "git+https://github.com/gw31415/satysfi-chemfml.git"
 bug-reports: "https://github.com/gw31415/satysfi-chemfml/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
+++ b/packages/satysfi-chemfml/satysfi-chemfml.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/gw31415/satysfi-chemfml"
 dev-repo: "git+https://github.com/gw31415/satysfi-chemfml.git"
 bug-reports: "https://github.com/gw31415/satysfi-chemfml/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-class-cv-doc/satysfi-class-cv-doc.0.1.0/opam
+++ b/packages/satysfi-class-cv-doc/satysfi-class-cv-doc.0.1.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/MasWag/cv-satysfi/issues"
 dev-repo: "git+https://github.com/MasWag/cv-satysfi.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-class-cv/satysfi-class-cv.0.1.0/opam
+++ b/packages/satysfi-class-cv/satysfi-class-cv.0.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/MasWag/cv-satysfi"
 bug-reports: "https://github.com/MasWag/cv-satysfi/issues"
 dev-repo: "git+https://github.com/MasWag/cv-satysfi.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-base" {>= "1.2.1" & < "2.0"}
   "satysfi-fonts-asana-math" {>= "000.958+1+satysfi0.0.4"}

--- a/packages/satysfi-class-exdesign-doc/satysfi-class-exdesign-doc.0.3.1/opam
+++ b/packages/satysfi-class-exdesign-doc/satysfi-class-exdesign-doc.0.3.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/exdesign/issues"
 dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 

--- a/packages/satysfi-class-exdesign/satysfi-class-exdesign.0.3.1/opam
+++ b/packages/satysfi-class-exdesign/satysfi-class-exdesign.0.3.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/exdesign/issues"
 dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
+++ b/packages/satysfi-class-jlreq/satysfi-class-jlreq.0.0.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/abenori/satysfi-class-jlreq/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-class-jlreq.git"
 license: "BSD-2-Clause-FreeBSD"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satysfi-fss" {>= "0.0.2" & < "0.3.0"}
   "satyrographos" {>= "0.0.2" & < "0.0.3.0"}

--- a/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi-doc/satysfi-class-mdbook-satysfi-doc.0.3.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-class-mdbook-satysfi.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
+++ b/packages/satysfi-class-mdbook-satysfi/satysfi-class-mdbook-satysfi.0.3.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-class-mdbook-satysfi.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-class-mdbook-satysfi/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
+++ b/packages/satysfi-class-slydifi-doc/satysfi-class-slydifi-doc.0.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/slydifi/issues"
 dev-repo: "git+https://github.com/monaqa/slydifi.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-slydifi" {= "%{version}%"}
   "satysfi-easytable" {>= "1.0.0" & < "2.0"}

--- a/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
+++ b/packages/satysfi-class-slydifi/satysfi-class-slydifi.0.5.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/slydifi/issues"
 dev-repo: "git+https://github.com/monaqa/slydifi.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-enumitem" {>= "3.0.1" & < "4.0"}
   "satysfi-figbox" {>= "0.1.3" & < "0.2.0"}

--- a/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle-doc/satysfi-class-stjarticle-doc.1.3.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/stjarticle"
 bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-class-stjarticle" {= "1.3.2"}

--- a/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
+++ b/packages/satysfi-class-stjarticle/satysfi-class-stjarticle.1.3.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/stjarticle"
 bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.9/opam
+++ b/packages/satysfi-class-yabaitech-doc/satysfi-class-yabaitech-doc.0.0.9/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
 bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
 dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-class-yabaitech" {= "0.0.9"}
 ]

--- a/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.9/opam
+++ b/packages/satysfi-class-yabaitech/satysfi-class-yabaitech.0.0.9/opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech"
 bug-reports: "https://github.com/yabaitechtokyo/satysfi-class-yabaitech/issues"
 dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-class-yabaitech.git"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-base" {>= "1.2.1" & < "2.0.0"}
   "satysfi-fonts-noto-sans" {>= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.1.1/opam
+++ b/packages/satysfi-code-printer-doc/satysfi-code-printer-doc.1.1.1/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.8" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-code-printer" {= "%{version}%"}
   "satysfi-dist"

--- a/packages/satysfi-code-printer/satysfi-code-printer.1.1.1/opam
+++ b/packages/satysfi-code-printer/satysfi-code-printer.1.1.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/puripuri2100/satysfi-code-printer.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-code-printer/issues"
 
 depends: [
-  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.0.8" }
+  "satysfi" { >= "0.0.6-53-g2867e4d9" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-base" { >= "1.4.0" & < "2.0" }

--- a/packages/satysfi-csv-doc/satysfi-csv-doc.1.0.0/opam
+++ b/packages/satysfi-csv-doc/satysfi-csv-doc.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-csv"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-csv.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-csv/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   "satysfi-csv" {= "%{version}%"}

--- a/packages/satysfi-csv/satysfi-csv.1.0.0/opam
+++ b/packages/satysfi-csv/satysfi-csv.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-csv"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-csv.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-csv/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   "satysfi-dist"

--- a/packages/satysfi-csvtable-doc/satysfi-csvtable-doc.1.1.0/opam
+++ b/packages/satysfi-csvtable-doc/satysfi-csvtable-doc.1.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/qwjyh/satysfi-csvtable"
 dev-repo: "git+https://github.com/qwjyh/satysfi-csvtable.git"
 bug-reports: "https://github.com/qwjyh/satysfi-csvtable/issues"
 depends: [
-  "satysfi" { >= "0.0.7" & < "0.0.8" }
+  "satysfi" { >= "0.0.7" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-csvtable/satysfi-csvtable.1.1.0/opam
+++ b/packages/satysfi-csvtable/satysfi-csvtable.1.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/qwjyh/satysfi-csvtable"
 dev-repo: "git+https://github.com/qwjyh/satysfi-csvtable.git"
 bug-reports: "https://github.com/qwjyh/satysfi-csvtable/issues"
 depends: [
-  "satysfi" { >= "0.0.7" & < "0.0.8" }
+  "satysfi" { >= "0.0.7" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `b` and `c`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (inconsistent-snapshot +satysfi-figbox)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (inconsistent-snapshot +satysfi-figbox)