### PR TITLE
Update upper version restriction for satysfi: D, E, and F

### DIFF
--- a/packages/satysfi-debug-show-value-doc/satysfi-debug-show-value-doc.0.1.2/opam
+++ b/packages/satysfi-debug-show-value-doc/satysfi-debug-show-value-doc.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-debug-show-value/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-debug-show-value.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 

--- a/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
+++ b/packages/satysfi-debug-show-value/satysfi-debug-show-value.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-debug-show-value/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-debug-show-value.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]

--- a/packages/satysfi-derive/satysfi-derive.1.0.0/opam
+++ b/packages/satysfi-derive/satysfi-derive.1.0.0/opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/yabaitechtokyo/satysfi-derive"
 bug-reports: "https://github.com/yabaitechtokyo/satysfi-derive/issues"
 dev-repo: "git+https://github.com/yabaitechtokyo/satysfi-derive.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satysfi-dist"
   "satysfi-base" {>= "1.3.0" & < "2.0.0"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}

--- a/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.2/opam
+++ b/packages/satysfi-easytable-doc/satysfi-easytable-doc.1.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
 
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.8"}
+  "satysfi" {>= "0.0.5" & < "0.1"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-easytable" {= "%{version}%"}

--- a/packages/satysfi-easytable/satysfi-easytable.1.1.2/opam
+++ b/packages/satysfi-easytable/satysfi-easytable.1.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-easytable/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-easytable.git"
 
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.8"}
+  "satysfi" {>= "0.0.5" & < "0.1"}
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>= "1.4.0" & < "2.0.0"}

--- a/packages/satysfi-enumitem-doc/satysfi-enumitem-doc.3.0.1/opam
+++ b/packages/satysfi-enumitem-doc/satysfi-enumitem-doc.3.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-enumitem/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-enumitem.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-enumitem" {= "%{version}%"}

--- a/packages/satysfi-enumitem/satysfi-enumitem.3.0.1/opam
+++ b/packages/satysfi-enumitem/satysfi-enumitem.3.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/monaqa/satysfi-enumitem/issues"
 dev-repo: "git+https://github.com/monaqa/satysfi-enumitem.git"
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>="1.0.0" & < "2.0.0"}

--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-figbox"
 dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
 bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-figbox"
 dev-repo: "git+https://github.com/monaqa/satysfi-figbox.git"
 bug-reports: "https://github.com/monaqa/satysfi-figbox/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-fss-doc/satysfi-fss-doc.0.2.0/opam
+++ b/packages/satysfi-fss-doc/satysfi-fss-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
 

--- a/packages/satysfi-fss-fontset-bodoni-star/satysfi-fss-fontset-bodoni-star.2.3/opam
+++ b/packages/satysfi-fss-fontset-bodoni-star/satysfi-fss-fontset-bodoni-star.2.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 
   "satysfi-fss" {>= "0.2.0" & < "0.3.0"}

--- a/packages/satysfi-fss/satysfi-fss.0.2.0/opam
+++ b/packages/satysfi-fss/satysfi-fss.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/na4zagin3/satysfi-fss"
 dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
 bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `d` to `f`.

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [ ] Add to snapshot `snapshot-develop` :: satysfi-figbox-doc.0.1.4 satysfi-figbox.0.1.4
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- [ ] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-figbox-doc.0.1.4 satysfi-figbox.0.1.4