### PR TITLE
Update upper version restriction for satysfi: G, I, K, L, and M

### DIFF
--- a/packages/satysfi-grcnum-doc/satysfi-grcnum-doc.0.2/opam
+++ b/packages/satysfi-grcnum-doc/satysfi-grcnum-doc.0.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/satyrographos"
 bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-grcnum.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.1" }
   "satyrographos" {>= "0.0.1" & < "0.0.3"}
   "satysfi-fonts-theano" {>= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
   "satysfi-dist"

--- a/packages/satysfi-grcnum/satysfi-grcnum.0.2/opam
+++ b/packages/satysfi-grcnum/satysfi-grcnum.0.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/satyrographos"
 bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-grcnum.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.1" }
   "satysfi-dist"
   "satysfi-fonts-theano" {>= "2.0+satysfi0.0.3+satyrograhos0.0.2"}
   "satyrographos" {>= "0.0.1" & < "0.0.3"}

--- a/packages/satysfi-image-doc/satysfi-image-doc.0.1.0/opam
+++ b/packages/satysfi-image-doc/satysfi-image-doc.0.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-image"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-image.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-image/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-image/satysfi-image.0.1.0/opam
+++ b/packages/satysfi-image/satysfi-image.0.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-image"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-image.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-image/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-karnaugh-doc/satysfi-karnaugh-doc.0.0.1/opam
+++ b/packages/satysfi-karnaugh-doc/satysfi-karnaugh-doc.0.0.1/opam
@@ -12,7 +12,7 @@ bug-reports:  "https://github.com/takagiy/satysfi-karnaugh/issues"
 dev-repo:     "git+https://github.com/takagiy/satysfi-karnaugh.git"
 license:      "MIT"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-karnaugh" {= "0.0.1"}

--- a/packages/satysfi-karnaugh/satysfi-karnaugh.0.0.1/opam
+++ b/packages/satysfi-karnaugh/satysfi-karnaugh.0.0.1/opam
@@ -12,7 +12,7 @@ bug-reports:  "https://github.com/takagiy/satysfi-karnaugh/issues"
 dev-repo:     "git+https://github.com/takagiy/satysfi-karnaugh.git"
 license:      "MIT"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: []

--- a/packages/satysfi-lipsum-doc/satysfi-lipsum-doc.0.2.1/opam
+++ b/packages/satysfi-lipsum-doc/satysfi-lipsum-doc.0.2.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
 
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-lipsum" {= "%{version}%"}

--- a/packages/satysfi-lipsum/satysfi-lipsum.0.2.1/opam
+++ b/packages/satysfi-lipsum/satysfi-lipsum.0.2.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-lipsum/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-lipsum.git"
 
 depends: [
-  "satysfi" {>= "0.0.4" & < "0.0.8"}
+  "satysfi" {>= "0.0.4" & < "0.1"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-make-html-doc/satysfi-make-html-doc.0.1.1/opam
+++ b/packages/satysfi-make-html-doc/satysfi-make-html-doc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-html/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-html.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-make-html" {= "%{version}%"}

--- a/packages/satysfi-make-html/satysfi-make-html.0.1.1/opam
+++ b/packages/satysfi-make-html/satysfi-make-html.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-html/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-html.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
+++ b/packages/satysfi-make-latex-doc/satysfi-make-latex-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-make-latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-make-latex" {= "%{version}%"}

--- a/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
+++ b/packages/satysfi-make-latex/satysfi-make-latex.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-latex/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-latex.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
+++ b/packages/satysfi-make-markdown/satysfi-make-markdown.0.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-make-markdown/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-make-markdown.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]

--- a/packages/satysfi-matrix-doc/satysfi-matrix-doc.0.0.1+dev2019.10.15/opam
+++ b/packages/satysfi-matrix-doc/satysfi-matrix-doc.0.0.1+dev2019.10.15/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/nekketsuuu/satysfi-matrix"
 bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
 dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-matrix" {= "%{version}%"}
 ]

--- a/packages/satysfi-matrix/satysfi-matrix.0.0.1+dev2019.10.15/opam
+++ b/packages/satysfi-matrix/satysfi-matrix.0.0.1+dev2019.10.15/opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/nekketsuuu/satysfi-matrix"
 bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
 dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [ ]

--- a/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
+++ b/packages/satysfi-matrixcd-doc/satysfi-matrixcd-doc.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
-  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi" {>= "0.0.6" & < "0.1"}
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satyrographos" {>= "0.0.2.0" & < "0.0.3"}
   "satysfi-dist"

--- a/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
+++ b/packages/satysfi-matrixcd/satysfi-matrixcd.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/abenori/satysfi-matrixcd/issues"
 dev-repo: "git+https://github.com/abenori/satysfi-matrixcd.git"
 license: "MIT"
 depends: [
-  "satysfi" {>= "0.0.6" & < "0.0.8"}
+  "satysfi" {>= "0.0.6" & < "0.1"}
   "satysfi-dist"
   "satysfi-base" {>= "1.3.0" & < "2.0"}
   "satyrographos" {>= "0.0.2.0" & < "0.0.3"}

--- a/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
+++ b/packages/satysfi-md2latex-doc/satysfi-md2latex-doc.0.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-md2latex" {= "%{version}%"}

--- a/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
+++ b/packages/satysfi-md2latex/satysfi-md2latex.0.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-md2latex"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-md2latex.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-md2latex/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.10" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-make-latex" {>= "0.2.0" & < "0.3.0"}

--- a/packages/satysfi-musikui-doc/satysfi-musikui-doc.0.1.1/opam
+++ b/packages/satysfi-musikui-doc/satysfi-musikui-doc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/musikui.satyh/issues"
 dev-repo: "git+https://github.com/puripuri2100/musikui.satyh.git"
 
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-musikui" {= "%{version}%"}

--- a/packages/satysfi-musikui/satysfi-musikui.0.1.1/opam
+++ b/packages/satysfi-musikui/satysfi-musikui.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/musikui.satyh/issues"
 dev-repo: "git+https://github.com/puripuri2100/musikui.satyh.git"
 
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `g` to `m`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)