### PR TITLE
Update upper version restriction for satysfi: N, P, Q, and R

### DIFF
--- a/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.2.1.0/opam
+++ b/packages/satysfi-ncsq-doc/satysfi-ncsq-doc.2.1.0/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/uemurax/satysfi-ncsq"
 bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-ncsq" {= "%{version}%"}

--- a/packages/satysfi-ncsq/satysfi-ncsq.2.1.0/opam
+++ b/packages/satysfi-ncsq/satysfi-ncsq.2.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/uemurax/satysfi-ncsq"
 bug-reports: "https://github.com/uemurax/satysfi-ncsq/issues"
 dev-repo: "git+https://github.com/uemurax/satysfi-ncsq.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-base" {>= "1.2.1" & < "2.0"}

--- a/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.4/opam
+++ b/packages/satysfi-num-conversion-doc/satysfi-num-conversion-doc.0.1.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-num-conversion" {= "%{version}%"}

--- a/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.4/opam
+++ b/packages/satysfi-num-conversion/satysfi-num-conversion.0.1.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-num-conversion/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-num-conversion.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-base" {>= "1.0.0"}
   "satysfi-dist"

--- a/packages/satysfi-pagenumber-doc/satysfi-pagenumber-doc.1.0.0/opam
+++ b/packages/satysfi-pagenumber-doc/satysfi-pagenumber-doc.1.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/abenori/satysfi-pagenumber"
 dev-repo: "git+https://github.com/abenori/satysfi-pagenumber.git"
 bug-reports: "https://github.com/abenori/satysfi-pagenumber/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
   "satysfi-pagenumber" {= "%{version}%"}

--- a/packages/satysfi-pagenumber/satysfi-pagenumber.1.0.0/opam
+++ b/packages/satysfi-pagenumber/satysfi-pagenumber.1.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/abenori/satysfi-pagenumber"
 dev-repo: "git+https://github.com/abenori/satysfi-pagenumber.git"
 bug-reports: "https://github.com/abenori/satysfi-pagenumber/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-base" { >= "1.4.0" & < "2.0.0" }
   "satysfi-dist"

--- a/packages/satysfi-pagestyle-doc/satysfi-pagestyle-doc.1.0.0/opam
+++ b/packages/satysfi-pagestyle-doc/satysfi-pagestyle-doc.1.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/abenori/satysfi-pagestyle"
 dev-repo: "git+https://github.com/abenori/satysfi-pagestyle.git"
 bug-reports: "https://github.com/abenori/satysfi-pagestyle/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
 

--- a/packages/satysfi-pagestyle/satysfi-pagestyle.1.0.0/opam
+++ b/packages/satysfi-pagestyle/satysfi-pagestyle.1.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/abenori/satysfi-pagestyle"
 dev-repo: "git+https://github.com/abenori/satysfi-pagestyle.git"
 bug-reports: "https://github.com/abenori/satysfi-pagestyle/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
 

--- a/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
+++ b/packages/satysfi-parallel-doc/satysfi-parallel-doc.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
 dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]

--- a/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
+++ b/packages/satysfi-parallel/satysfi-parallel.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/MasWag/satysfi-parallel/issues"
 dev-repo: "git+https://github.com/MasWag/satysfi-parallel.git"
 
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]

--- a/packages/satysfi-quotation-doc/satysfi-quotation-doc.0.2.0/opam
+++ b/packages/satysfi-quotation-doc/satysfi-quotation-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-quotation"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-quotation.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-quotation/issues"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-quotation/satysfi-quotation.0.2.0/opam
+++ b/packages/satysfi-quotation/satysfi-quotation.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-quotation"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-quotation.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-quotation/issues"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
+++ b/packages/satysfi-railway-doc/satysfi-railway-doc.0.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-railway"
 dev-repo: "git+https://github.com/monaqa/satysfi-railway.git"
 bug-reports: "https://github.com/monaqa/satysfi-railway/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
 

--- a/packages/satysfi-railway/satysfi-railway.0.1.0/opam
+++ b/packages/satysfi-railway/satysfi-railway.0.1.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-railway"
 dev-repo: "git+https://github.com/monaqa/satysfi-railway.git"
 bug-reports: "https://github.com/monaqa/satysfi-railway/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
+++ b/packages/satysfi-ruby-doc/satysfi-ruby-doc.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-ruby/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-ruby.git"
 
 depends: [
-  "satysfi" { >= "0.0.1" & < "0.0.8" }
+  "satysfi" { >= "0.0.1" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-ruby" {"%{version}%"}

--- a/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
+++ b/packages/satysfi-ruby/satysfi-ruby.0.1.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-ruby/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-ruby.git"
 
 depends: [
-  "satysfi" { >= "0.0.1" & < "0.0.8" }
+  "satysfi" { >= "0.0.1" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
 ]


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `n` to `r`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)