### PR TITLE
Update upper version restriction for satysfi: S to Z

### DIFF
--- a/packages/satysfi-simple-itemize-doc/satysfi-simple-itemize-doc.1.0.2/opam
+++ b/packages/satysfi-simple-itemize-doc/satysfi-simple-itemize-doc.1.0.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-simple-itemize/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-simple-itemize.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-simple-itemize" {= "%{version}%"}

--- a/packages/satysfi-simple-itemize/satysfi-simple-itemize.1.0.2/opam
+++ b/packages/satysfi-simple-itemize/satysfi-simple-itemize.1.0.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-simple-itemize/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-simple-itemize.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-base" {>="1.0.0"}
   "satysfi-dist"

--- a/packages/satysfi-siunitx-doc/satysfi-siunitx-doc.0.1.1/opam
+++ b/packages/satysfi-siunitx-doc/satysfi-siunitx-doc.0.1.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-siunitx"
 bug-reports: "https://github.com/puripuri2100/SATySFi-siunitx/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-siunitx.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-siunitx" {= "%{version}%"}

--- a/packages/satysfi-siunitx/satysfi-siunitx.0.1.1/opam
+++ b/packages/satysfi-siunitx/satysfi-siunitx.0.1.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-siunitx"
 bug-reports: "https://github.com/puripuri2100/SATySFi-siunitx/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-siunitx.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-test/satysfi-test.0.0.1/opam
+++ b/packages/satysfi-test/satysfi-test.0.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/satysfi-test"
 dev-repo: "git+https://github.com/zeptometer/satysfi-test.git"
 bug-reports: "https://github.com/zeptometer/satysfi-test/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.8" & < "0.0.3" }
   "satysfi-dist"
 ]

--- a/packages/satysfi-texlogo-doc/satysfi-texlogo-doc.0.1.1/opam
+++ b/packages/satysfi-texlogo-doc/satysfi-texlogo-doc.0.1.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-texlogo"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-texlogo.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-texlogo/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-texlogo/satysfi-texlogo.0.1.1/opam
+++ b/packages/satysfi-texlogo/satysfi-texlogo.0.1.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-texlogo"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-texlogo.git"
 bug-reports: "https://github.com/puripuri2100/SATySFi-texlogo/issues"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.2.0/opam
+++ b/packages/satysfi-tombo-doc/satysfi-tombo-doc.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-tombo"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-dist"
 

--- a/packages/satysfi-tombo/satysfi-tombo.0.2.0/opam
+++ b/packages/satysfi-tombo/satysfi-tombo.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/satysfi-tombo"
 dev-repo: "git+https://github.com/puripuri2100/satysfi-tombo.git"
 bug-reports: "https://github.com/puripuri2100/satysfi-tombo/issues"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # If your library depends on other libraries, please write down here

--- a/packages/satysfi-uline-doc/satysfi-uline-doc.0.2.2/opam
+++ b/packages/satysfi-uline-doc/satysfi-uline-doc.0.2.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-uline/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-uline.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
   "satysfi-uline" {= "%{version}%"}

--- a/packages/satysfi-uline/satysfi-uline.0.2.2/opam
+++ b/packages/satysfi-uline/satysfi-uline.0.2.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/puripuri2100/SATySFi-uline/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-uline.git"
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
   "satysfi-dist"
 ]

--- a/packages/satysfi-zrbase/satysfi-zrbase.0.4.0/opam
+++ b/packages/satysfi-zrbase/satysfi-zrbase.0.4.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/zr-tex8r/satysfi-zrbase"
 bug-reports: "https://github.com/zr-tex8r/satysfi-zrbase"
 dev-repo: "git+https://github.com/zr-tex8r/satysfi-zrbase.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for packages that start with `s` to `z`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)