### PR TITLE
Update upper version restriction for satysfi: fonts

### DIFF
--- a/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.958+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.958+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satysfi-dist"
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.958+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.958+1+satysfi0.0.4/opam
@@ -25,7 +25,7 @@ extra-source "Asana-Math.otf" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 install: [

--- a/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star-doc/satysfi-fonts-bodoni-star-doc.2.3+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-bodoni-star/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-bodoni-star.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-bodoni-star" {= "%{version}%"}

--- a/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-bodoni-star/satysfi-fonts-bodoni-star.2.3+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "Bodoni-master.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil-doc/satysfi-fonts-charis-sil-doc.1.0.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/yuhr/satysfi-fonts-charis-sil"
 bug-reports: "https://github.com/yuhr/satysfi-fonts-charis-sil/issues"
 dev-repo: "git+https://github.com/yuhr/satysfi-fonts-charis-sil.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
   "satysfi-fonts-charis-sil" {= "%{version}%"}
   "satysfi-dist"

--- a/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
+++ b/packages/satysfi-fonts-charis-sil/satysfi-fonts-charis-sil.1.0.0/opam
@@ -19,7 +19,7 @@ extra-source "CharisSIL-5.000.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 build: [

--- a/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode-doc/satysfi-fonts-computer-modern-unicode-doc.0.7.0+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-computer-modern-unicode.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-computer-modern-unicode" {= "0.7.0+satysfi0.0.4"}

--- a/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-computer-modern-unicode/satysfi-fonts-computer-modern-unicode.0.7.0+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "computer-modern-unicode.tar.xz" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant-doc/satysfi-fonts-cormorant-doc.3.601+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-cormorant"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-cormorant/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-cormorant.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-cormorant" {= "%{version}%"}

--- a/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-cormorant/satysfi-fonts-cormorant.3.601+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "Cormorant_Install_v3.601.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-dejavu-doc/satysfi-fonts-dejavu-doc.2.37+satysfi0.0.4/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-dejavu"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-dejavu/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-dejavu.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-dejavu" {= "2.37+satysfi0.0.4"}
 ]

--- a/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-dejavu/satysfi-fonts-dejavu.2.37+satysfi0.0.4/opam
@@ -18,7 +18,7 @@ extra-source "dejavu-fonts-ttf-2.37.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.12" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp-doc/satysfi-fonts-han-sans-jp-doc.2.003R/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-sans-jp.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-han-sans-jp" { = "%{version}%" }

--- a/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
+++ b/packages/satysfi-fonts-han-sans-jp/satysfi-fonts-han-sans-jp.2.003R/opam
@@ -19,7 +19,7 @@ extra-source "SourceHanSansJP.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-han-serif-jp-doc/satysfi-fonts-han-serif-jp-doc.1.001R/opam
+++ b/packages/satysfi-fonts-han-serif-jp-doc/satysfi-fonts-han-serif-jp-doc.1.001R/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-han-serif-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-han-serif-jp" { = "%{version}%" }

--- a/packages/satysfi-fonts-han-serif-jp/satysfi-fonts-han-serif-jp.1.001R/opam
+++ b/packages/satysfi-fonts-han-serif-jp/satysfi-fonts-han-serif-jp.1.001R/opam
@@ -19,7 +19,7 @@ extra-source "SourceHanSerifJP.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-ibm-plex-sans-jp-doc/satysfi-fonts-ibm-plex-sans-jp-doc.1.0.0/opam
+++ b/packages/satysfi-fonts-ibm-plex-sans-jp-doc/satysfi-fonts-ibm-plex-sans-jp-doc.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp"
 dev-repo: "git+https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp.git"
 bug-reports: "https://github.com/monaqa/satysfi-fonts-ibm-plex-sans-jp/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-fonts-ibm-plex-sans-jp/satysfi-fonts-ibm-plex-sans-jp.1.0.0/opam
+++ b/packages/satysfi-fonts-ibm-plex-sans-jp/satysfi-fonts-ibm-plex-sans-jp.1.0.0/opam
@@ -17,7 +17,7 @@ extra-source "OpenType.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 build: [

--- a/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata-doc/satysfi-fonts-inconsolata-doc.3.001/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-inconsolata/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-inconsolata.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-dist"

--- a/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
+++ b/packages/satysfi-fonts-inconsolata/satysfi-fonts-inconsolata.3.001/opam
@@ -19,7 +19,7 @@ extra-source "inconsolata.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode-doc/satysfi-fonts-junicode-doc.1.0002+satysfi0.0.5/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-junicode"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-junicode/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-junicode.git"
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-junicode" {= "%{version}%"}

--- a/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
+++ b/packages/satysfi-fonts-junicode/satysfi-fonts-junicode.1.0002+satysfi0.0.5/opam
@@ -19,7 +19,7 @@ extra-source "junicode-1.002.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.5" & < "0.0.8" }
+  "satysfi" { >= "0.0.5" & < "0.1" }
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons-doc/satysfi-fonts-material-icons-doc.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/monaqa/satysfi-fonts-material-icons"
 dev-repo: "git+https://github.com/monaqa/satysfi-fonts-material-icons.git"
 bug-reports: "https://github.com/monaqa/satysfi-fonts-material-icons/issues"
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
   # You may want to include the corresponding library

--- a/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
+++ b/packages/satysfi-fonts-material-icons/satysfi-fonts-material-icons.1.0.1/opam
@@ -36,7 +36,7 @@ extra-source "MaterialIconsTwoTone-Regular.otf" {
 }
 
 depends: [
-  "satysfi" { >= "0.0.6" & < "0.0.8" }
+  "satysfi" { >= "0.0.6" & < "0.1" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 ]
 install: [

--- a/packages/satysfi-fonts-noto-emoji-doc/satysfi-fonts-noto-emoji-doc.1.05+uh+2/opam
+++ b/packages/satysfi-fonts-noto-emoji-doc/satysfi-fonts-noto-emoji-doc.1.05+uh+2/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-emoji"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-emoji/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-emoji.git"
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-emoji" {>= "1.05+uh+2"}

--- a/packages/satysfi-fonts-noto-emoji/satysfi-fonts-noto-emoji.1.05+uh+2/opam
+++ b/packages/satysfi-fonts-noto-emoji/satysfi-fonts-noto-emoji.1.05+uh+2/opam
@@ -23,7 +23,7 @@ extra-source "noto-emoji-2019-11-19-unicode12.zip" {
 
 
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.4"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp-doc/satysfi-fonts-noto-sans-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans-cjk-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-sans-cjk-jp" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-jp/satysfi-fonts-noto-sans-cjk-jp.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans-cjk-jp.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc-doc/satysfi-fonts-noto-sans-cjk-sc-doc.2.001+1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc"
 bug-reports: "https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc/issues"
 dev-repo: "git+https://github.com/puripuri2100/SATySFi-fonts-noto-sans-cjk-sc.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-fonts-noto-sans-cjk-sc" {= "%{version}%"}
 ]

--- a/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
+++ b/packages/satysfi-fonts-noto-sans-cjk-sc/satysfi-fonts-noto-sans-cjk-sc.2.001+1/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans-cjk-sc.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-sans-doc/satysfi-fonts-noto-sans-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans-doc/satysfi-fonts-noto-sans-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-sans"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-sans/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-sans.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-sans" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-sans/satysfi-fonts-noto-sans.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-sans/satysfi-fonts-noto-sans.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-sans.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp-doc/satysfi-fonts-noto-serif-cjk-jp-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif-cjk-jp.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-serif-cjk-jp" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-cjk-jp/satysfi-fonts-noto-serif-cjk-jp.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-serif-cjk-jp.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-noto-serif-doc/satysfi-fonts-noto-serif-doc.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif-doc/satysfi-fonts-noto-serif-doc.2.001+1+satysfi0.0.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-noto-serif"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-noto-serif/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-noto-serif.git"
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-base" {>= "1.2.0"}
   "satysfi-fonts-noto-serif" {= "2.001+1+satysfi0.0.4"}

--- a/packages/satysfi-fonts-noto-serif/satysfi-fonts-noto-serif.2.001+1+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-noto-serif/satysfi-fonts-noto-serif.2.001+1+satysfi0.0.4/opam
@@ -19,7 +19,7 @@ extra-source "noto-serif.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.4" & < "0.0.8" }
+  "satysfi" { >= "0.0.4" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [

--- a/packages/satysfi-fonts-theano-doc/satysfi-fonts-theano-doc.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
+++ b/packages/satysfi-fonts-theano-doc/satysfi-fonts-theano-doc.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/na4zagin3/SATySFi-fonts-theano"
 bug-reports: "https://github.com/na4zagin3/SATySFi-fonts-theano/issues"
 dev-repo: "git+https://github.com/na4zagin3/SATySFi-fonts-theano.git"
 depends: [
-  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.0.8" }
+  "satysfi" { >= "0.0.3+dev2019.02.13" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
   "satysfi-dist"
   "satysfi-fonts-theano"

--- a/packages/satysfi-fonts-theano/satysfi-fonts-theano.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
+++ b/packages/satysfi-fonts-theano/satysfi-fonts-theano.2.0+satysfi0.0.3+satyrograhos0.0.2/opam
@@ -19,7 +19,7 @@ extra-source "theano-2.0.otf.zip" {
   ]
 }
 depends: [
-  "satysfi" { >= "0.0.3" & < "0.0.8" }
+  "satysfi" { >= "0.0.3" & < "0.1" }
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: [


### PR DESCRIPTION
This PR split from https://github.com/na4zagin3/satyrographos-repo/pull/504. This updates version restriction on satysfi for font packages.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)