### PR TITLE
Add satysfi-azmath-doc.0.0.3+1 that supports enumitem 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           set -exo pipefail
           echo "### OPAM Lint" | tee -a "pr/comment.txt"
-          git diff --name-status origin/master... -- packages/ | sed -e '/^D/d' -e 's/^\w*\s//' | xargs opam lint --color=never --strict | tee -a "pr/comment.txt"
+          git diff --name-status origin/master... -- packages/ | sed -e '/^D/d' -e 's/^\w*\s//' -e '/\/opam/!d' | xargs opam lint --color=never --strict | tee -a "pr/comment.txt"
 
       - name: Install the snapshot
         run: |

--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3+1/files/azmath-enumitem-3.patch
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3+1/files/azmath-enumitem-3.patch
@@ -1,0 +1,111 @@
+diff --git a/doc/azmath.saty b/doc/azmath.saty
+index f849973..43f6429 100644
+--- a/doc/azmath.saty
++++ b/doc/azmath.saty
+@@ -45,6 +45,11 @@ let-block +example str bt =
+     +block-frame(bt);
+   >%
+ 
++let-block +dd dt bt-dd =
++  '<
++    +EnumitemAlias.ditem{#dt;}{}<#bt-dd;>
++  >
++
+ let-math \p-big m =
+   let mathf ctx =
+     let (_, ht, _) = get-natural-metrics (embed-math ctx ${\sqrt{2}}) in
+@@ -489,38 +494,63 @@ document (|
+       パラメータを指定してその振る舞いを変更することができます。
+     }
+ 
+-    +description{
+-      * `allow-display-break`
+-        ** bool 型のパラメータ。デフォルトは `true`。
+-        ** 別行立て数式の途中で改行することを許すかどうか。
+-           false にすると別行立て数式に入る直前及び、
+-           別行立て数式の行の間では改行ができない。
+-
+-      * `vmargin-between-eqn`
+-        ** `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> (get-font-size ctx) *' 0.6)`。
+-        ** 数式同士の間の余白。テキスト処理文脈を引数に取る関数の形で指定する。
+-           たとえば `(fun ctx -> (get-font-size ctx) *' 1.5)` とすると
+-           現在のフォントサイズの 1.5 倍の高さとなり、
+-           `(fun _ -> 20pt)` とすると現在のフォントサイズなどによらず20ptとなる。
+-
+-      * `vmargin-between-eqn`, `vmargin-after-eqn`
+-        ** `context -> length` 型のパラメータ。デフォルトはともに `(fun ctx -> (get-font-size ctx) *' 1.0)`。
+-        ** 別行立て数式前後の余白（段落間空白）。
+-
+-      * `min-gap-between-eqn-and-tag`
+-        ** `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> 2pt)`。
+-        ** 数式やタグがどこまで近づいてよいか。
+-           数式を整列させたとき、数式の右端とタグの左端がこのパラメータで示す値以上無かった場合、
+-           タグは数式の下に回り込んで組まれる。
+-           テキスト処理文脈を引数に取る関数の形で指定する。
+-
+-      * `vmargin-between-eqn-and-tag`
+-        ** `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> (get-font-size ctx) *' 0.3)`。
+-        ** 数式やタグが長いためにタグが数式の下に回り込んだ際に、
+-           数式とタグの間に入る縦方向の余白。
+-           テキスト処理文脈を引数に取る関数の形で指定する。
++    +description<
++      +dd{`allow-display-break`}<
++        +pn{
++          bool 型のパラメータ。デフォルトは `true`。
++        }
++        +pn{
++          別行立て数式の途中で改行することを許すかどうか。
++          false にすると別行立て数式に入る直前及び、
++          別行立て数式の行の間では改行ができない。
++        }
++      >
+ 
+-    }
++      +dd{`vmargin-between-eqn`}<
++        +pn{
++          `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> (get-font-size ctx) *' 0.6)`。
++        }
++        +pn{
++          数式同士の間の余白。テキスト処理文脈を引数に取る関数の形で指定する。
++          たとえば `(fun ctx -> (get-font-size ctx) *' 1.5)` とすると
++          現在のフォントサイズの 1.5 倍の高さとなり、
++          `(fun _ -> 20pt)` とすると現在のフォントサイズなどによらず20ptとなる。
++        }
++      >
++
++      +dd{`vmargin-between-eqn`, `vmargin-after-eqn`}<
++        +pn{
++          `context -> length` 型のパラメータ。デフォルトはともに `(fun ctx -> (get-font-size ctx) *' 1.0)`。
++        }
++        +pn{
++          別行立て数式前後の余白（段落間空白）。
++        }
++      >
++
++      +dd{`min-gap-between-eqn-and-tag`}<
++        +pn{
++          `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> 2pt)`。
++        }
++        +pn{
++          数式やタグがどこまで近づいてよいか。
++          数式を整列させたとき、数式の右端とタグの左端がこのパラメータで示す値以上無かった場合、
++          タグは数式の下に回り込んで組まれる。
++          テキスト処理文脈を引数に取る関数の形で指定する。
++        }
++      >
++
++      +dd{`vmargin-between-eqn-and-tag`}<
++        +pn{
++          `context -> length` 型のパラメータ。デフォルトは `(fun ctx -> (get-font-size ctx) *' 0.3)`。
++        }
++        +pn{
++          数式やタグが長いためにタグが数式の下に回り込んだ際に、
++          数式とタグの間に入る縦方向の余白。
++          テキスト処理文脈を引数に取る関数の形で指定する。
++        }
++      >
++
++    >
+ 
+     +p{
+       パラメータはプリアンブルで以下のように指定することができます。

--- a/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3+1/opam
+++ b/packages/satysfi-azmath-doc/satysfi-azmath-doc.0.0.3+1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A SATySFi package containing A-to-Z mathematical commands"
+description: """A SATySFi package containing A-to-Z mathematical commands."""
+
+maintainer: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+authors: "Shinichi Mogami <mogassy@yahoo.co.jp>"
+license: "MIT"
+homepage: "https://github.com/monaqa/satysfi-azmath"
+bug-reports: "https://github.com/monaqa/satysfi-azmath/issues"
+dev-repo: "git+https://github.com/monaqa/satysfi-azmath.git"
+
+depends: [
+  "satysfi" { >= "0.0.5" & < "0.1" }
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-dist"
+  "satysfi-azmath" {= "0.0.3"}
+  "satysfi-enumitem" {>= "3.0.0" & < "4.0"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "azmath-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+extra-files: [
+  ["azmath-enumitem-3.patch" "sha512=454ffdb7ddfde50c39a76a2c8ffc7b5e1450bb4569b4181bb00af4611c6381f0d11f3aa99f837a767d47f64bc38e8550fa77c89bf7bcb53f723e928ea1ace009"]
+]
+patches: [ "azmath-enumitem-3.patch" ]
+url {
+  src: "https://github.com/monaqa/satysfi-azmath/archive/v0.0.3.tar.gz"
+  checksum: [
+    "md5=872911500b9ce8c45cb9e38fe5fe0b4b"
+    "sha512=725917ab03e5599f7ef2d5065afa904197bf58ddd61ebec0b7dd160f1bce1e60bbfe4fecddc40f753c6e33fc103fe5a0ef36d3fe9dcab58c40bb2236617b3812"
+  ]
+}

--- a/snapshot-develop.opam
+++ b/snapshot-develop.opam
@@ -32,6 +32,10 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath-doc" {= "0.0.3+1"}
+
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.5.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}

--- a/snapshot-stable-0-0-6--1.opam
+++ b/snapshot-stable-0-0-6--1.opam
@@ -32,6 +32,10 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath-doc" {= "0.0.3+1"}
+
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.5.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}

--- a/snapshot-stable-0-0-7.opam
+++ b/snapshot-stable-0-0-7.opam
@@ -32,6 +32,10 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath-doc" {= "0.0.3+1"}
+
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.5.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}

--- a/snapshot-stable-0-0-8.opam
+++ b/snapshot-stable-0-0-8.opam
@@ -32,6 +32,10 @@ depends: [
 
   "satysfi-assert-eq" {= "0.1.2"}
 
+  "satysfi-azmath-doc" {= "0.0.3+1"}
+
+  "satysfi-azmath" {= "0.0.3"}
+
   "satysfi-base" {= "1.5.0"}
 
   "satysfi-bibyfi-doc" {= "0.0.2"}


### PR DESCRIPTION
This allows to add other packages depending on azmath to snapshots.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)