### PR TITLE
Update version constraint on satysfi-dist

### DIFF
--- a/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
+++ b/packages/satysfi-figbox-doc/satysfi-figbox-doc.0.1.4/opam
@@ -18,7 +18,7 @@ depends: [
 
   # Other libraries
   "satysfi-dist"
-  "satysfi-base" {>= "1.4.0"}
+  "satysfi-base" {>= "1.4.0" & < "2.0"}
   "satysfi-easytable" {>= "1.0.0" & < "2"}
   "satysfi-enumitem" {>= "3.0.0" & < "4.0" }
 ]

--- a/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
+++ b/packages/satysfi-figbox/satysfi-figbox.0.1.4/opam
@@ -15,7 +15,7 @@ depends: [
 
   # If your library depends on other libraries, please write down here
   "satysfi-dist"
-  "satysfi-base" {>= "1.4.0"}
+  "satysfi-base" {>= "1.4.0" & < "2.0"}
 ]
 install: [
   ["satyrographos" "opam" "install"


### PR DESCRIPTION
Specify upper bound of `satysfi-base`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-figbox-doc.0.1.4 satysfi-figbox.0.1.4
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-figbox-doc.0.1.4 satysfi-figbox.0.1.4
- [x] Add to snapshot `snapshot-stable-0-0-8` :: satysfi-figbox-doc.0.1.4 satysfi-figbox.0.1.4