### PR TITLE
[satysfi-dist] Use HTTPS for GUST fonts

### DIFF
--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.10/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.02.13/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.03.10/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.07.14/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.3+dev2019.11.16/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.09/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.09/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.16/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.16/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.22/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.02.22/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.05/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.25/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.04.25/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.06.07/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4+dev2020.06.07/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.4/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.4/opam
@@ -6,14 +6,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5+dev2020.09.05/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5-59-g32f2525/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5-59-g32f2525/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5-83-g360d941/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5-83-g360d941/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.5/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.5/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.6-25-g4083234/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.6-25-g4083234/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.6-32-g9dbd61d/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.6-32-g9dbd61d/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.6-43-ga86452bc/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.6-43-ga86452bc/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.6-53-g2867e4d9/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.6-53-g2867e4d9/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.6/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.6/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.7-20-g748112c2/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.7-20-g748112c2/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.7-26-g9f4b68ec/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.7-26-g9f4b68ec/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.7/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.7/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi-dist/satysfi-dist.0.0.8/opam
+++ b/packages/satysfi-dist/satysfi-dist.0.0.8/opam
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
+++ b/packages/satysfi/satysfi.0.0.3+dev2018.10.29/opam
@@ -9,14 +9,14 @@ homepage: "https://github.com/gfngfn/SATySFi"
 dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
 bug-reports: "https://github.com/gfngfn/SATySFi/issues"
 extra-source "lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/packages/satysfi/satysfi.0.0.3/opam
+++ b/packages/satysfi/satysfi.0.0.3/opam
@@ -9,14 +9,14 @@ homepage: "https://github.com/gfngfn/SATySFi"
 dev-repo: "git+https://github.com/gfngfn/SATySFi.git"
 bug-reports: "https://github.com/gfngfn/SATySFi/issues"
 extra-source "lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"

--- a/resources/satysfi-dist.template
+++ b/resources/satysfi-dist.template
@@ -4,14 +4,14 @@ authors: [
   "gfngfn"
 ]
 extra-source "temp/lm2.004otf.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
   checksum: [
     "sha256=5b0236051d3728be6616f1b274e3b910473875b5a3ef9382f0ef00384ddb161b"
     "sha512=c63068c86590e768498ef5f68a17a737aa40981432d8f6366c29760ea032a603ddd3d748d348ab259beba77966c292f9382b1fe9eb7a78af0926c6abc71f6f81"
   ]
 }
 extra-source "temp/latinmodern-math-1959.zip" {
-  archive: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+  archive: "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
   checksum: [
     "sha256=aaaa060b4ffc091461e875efb9498b9abfa7c7a48f38eb33882868839903a4f8"
     "sha512=b4fb4b575107b56eee0fed7971b09d334d4b162842675cf5f5ff7cb12e08099fb00755c81ddc1f04138f87b216592299028906165e2cec43521c6ca61b466d4c"


### PR DESCRIPTION
Replaced all occurrences of `http://www.gust.org.pl` to `https://www.gust.org.pl` as `www.gust.org.pl` returns 404 for HTTP access.

* Fix #575 
* Related to gfngfn/satysfi#411

Tested with `satysfi-dist.0.0.5`, `satysfi-dist.0.0.6`, `satysfi-dist.0.0.7` and `satysfi-dist.0.0.8` (installation of less than 0.0.5 was difficult because it requires OCaml 3, but I think it is old enough)
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)