### PR TITLE
Disable --strict option for OPAM 2.0/2.1

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -24,6 +24,8 @@ case "$(opam --version)" in
     2.0.*|2.1.*)
         echo "Enable workaround for OPAM Bug #5132"
         WORKAROUND_OPAM_BUG_5132=1
+        echo "Enable workaround for #655"
+        WORKAROUND_OPAM_BUG_STRICT=1
         ;;
 esac
 


### PR DESCRIPTION
This commit disables option `--strict` because new variable `with-dev-setup`  has already been used by some packages in opam-repository.

Fixes https://github.com/na4zagin3/satyrographos-repo/issues/655
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)