### PR TITLE
Trigger PR CI for more conditions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: Pull Request Flow
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [assigned, opened, synchronize, reopened]
 # tags-ignore and/or paths does not work with pull_request_target
 #    tags-ignore:
 #      - "automated pr"


### PR DESCRIPTION
Added `assigned` and `synchronize` triggers to `pull_request_target`.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)