### PR TITLE
Relax version restriction of satyrographos.0.0.2.4 on OCaml

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.4/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.4/opam
@@ -17,11 +17,6 @@ run-test: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  (
-    "dune" {>= "1.11"} & "ocaml" {>= "4.07.0"}
-  | (* ppx_inline_test v0.11 requires dune 1 *)
-    "dune" {>= "1.11" & < "2" } & "ocaml" {< "4.07.0"}
-  )
   "fileutils"
   "json-derivers"
   "ppx_deriving"


### PR DESCRIPTION

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- Add to snapshot `snapshot-stable-0-0-5`
- Add to snapshot `snapshot-stable-0-0-6`
- Add to snapshot `snapshot-stable-0-0-6--1`
- Add to snapshot `snapshot-stable-0-0-7`
- Add to snapshot `snapshot-stable-0-0-8`