### PR TITLE
2 packages from zeptometer/SATySFi-fonts-asana-math at 000.962+satysfi0.0.4

### DIFF
--- a/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for Asana Math Fonts"
+description: """
+Document package for satysfi-fonts-asana-math
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "CC0-1.0"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.1.0"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-fonts-asana-math" {= "000.962+satysfi0.0.4"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-asana-math-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-asana-math-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-asana-math/archive/refs/tags/000.962+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=de8dde15fb43c42ab0ecfb8f930d59eb"
+    "sha512=b0d66fd87893a5da08a55098163fd574f884242c833d513580527c59932b410338a46ad2046c401e020da038c664c1493a13b21d83668e3288fa2217ccee76d7"
+  ]
+}

--- a/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math-doc/satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 depends: [
   "satysfi" {>= "0.0.4" & < "0.1.0"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-fonts-asana-math" {= "000.962+satysfi0.0.4"}
 ]
 build: [

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 extra-source "Asana-Math.otf" {
-  archive: "http://mirrors.ctan.org/fonts/Asana-Math/Asana-Math.otf"
+  archive: "https://raw.githubusercontent.com/na4zagin3/satysfi-dist-font-archives/190ce5837e908d4d328f15d9fe748c97e1c376d5/Asana-Math/2025-11-19/Asana-Math.otf"
   checksum: [
     "sha256=9fa3bd7294acd349162ca119351212f7712d26442a3089abcb70bb327b03caf1"
     "sha512=b85ee0683e4fc3f046c80500780a37e0e9a0453fe3c3414118bd5adcf468c77704739fdcf009de494a8bbabf484b091d5a9ede56057a0b67af1ecd12ed6145a6"

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
@@ -20,7 +20,7 @@ extra-source "Asana-Math.otf" {
 }
 depends: [
   "satysfi" {>= "0.0.4" & < "0.1.0"}
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
 ]
 install: [
   ["satyrographos" "opam" "install"

--- a/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
+++ b/packages/satysfi-fonts-asana-math/satysfi-fonts-asana-math.000.962+satysfi0.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for Asana Math Fonts"
+description: """
+SATySFi font package for Asana Math fonts.
+
+This package installs fonts from http://mirrors.ctan.org/fonts/Asana-Math/.
+"""
+maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
+authors: "MURASE Yuito <yuito.murase@gmail.com>"
+license: "OFL-1.1"
+homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
+bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
+dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
+extra-source "Asana-Math.otf" {
+  archive: "http://mirrors.ctan.org/fonts/Asana-Math/Asana-Math.otf"
+  checksum: [
+    "sha256=9fa3bd7294acd349162ca119351212f7712d26442a3089abcb70bb327b03caf1"
+    "sha512=b85ee0683e4fc3f046c80500780a37e0e9a0453fe3c3414118bd5adcf468c77704739fdcf009de494a8bbabf484b091d5a9ede56057a0b67af1ecd12ed6145a6"
+  ]
+}
+depends: [
+  "satysfi" {>= "0.0.4" & < "0.1.0"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-asana-math"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/zeptometer/SATySFi-fonts-asana-math/archive/refs/tags/000.962+satysfi0.0.4.tar.gz"
+  checksum: [
+    "md5=de8dde15fb43c42ab0ecfb8f930d59eb"
+    "sha512=b0d66fd87893a5da08a55098163fd574f884242c833d513580527c59932b410338a46ad2046c401e020da038c664c1493a13b21d83668e3288fa2217ccee76d7"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `satysfi-fonts-asana-math.000.962+satysfi0.0.4`: SATySFi Font Package for Asana Math Fonts
- `satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4`: Document of SATySFi Font Package for Asana Math
  Fonts



---
* Homepage: https://github.com/zeptometer/SATySFi-fonts-asana-math
* Source repo: git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git
* Bug tracker: https://github.com/zeptometer/SATySFi-fonts-asana-math/issues

---
:camel: Pull-request generated by opam-publish v2.3.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-10` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-11` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- [x] Add to snapshot `snapshot-stable-0-0-5` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-6` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-6--1` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-7` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4
- [x] Add to snapshot `snapshot-stable-0-0-8` :: satysfi-fonts-asana-math-doc.000.962+satysfi0.0.4 satysfi-fonts-asana-math.000.962+satysfi0.0.4