### PR TITLE
2 packages from ghaaj/satysfi-fonts-new-computer-modern at 7.1.1

### DIFF
--- a/packages/satysfi-fonts-new-computer-modern-doc/satysfi-fonts-new-computer-modern-doc.7.1.1/opam
+++ b/packages/satysfi-fonts-new-computer-modern-doc/satysfi-fonts-new-computer-modern-doc.7.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Document of SATySFi Font Package for New Computer Modern"
+description: """
+Document of SATySFi Font Package for New Computer Modern.
+"""
+maintainer: "ghaaj <91141283+ghaaj@users.noreply.github.com>"
+authors: "ghaaj <91141283+ghaaj@users.noreply.github.com>"
+license: "MIT"
+homepage: "https://github.com/ghaaj/satysfi-fonts-new-computer-modern"
+dev-repo: "git+https://github.com/ghaaj/satysfi-fonts-new-computer-modern.git"
+bug-reports: "https://github.com/ghaaj/satysfi-fonts-new-computer-modern/issues"
+depends: [
+  "satysfi" { >= "0.0.10" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+
+  "satysfi-fonts-new-computer-modern" {= "%{version}%"}
+
+  "satysfi-dist"
+  "satysfi-base"
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "fonts-new-computer-modern-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-new-computer-modern-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/ghaaj/satysfi-fonts-new-computer-modern/archive/refs/tags/v7.1.1.tar.gz"
+  checksum: [
+    "md5=0cf4bf839cab9847ca72901203a1fd30"
+    "sha512=f6a1edd68155cee787590c185a105ead9b36e4fc22e96939a1d4d4a4e1f105c0462a6e2613d8152ef662b62cf0fb359ec3ecaa884b819f254bc4a29544876c07"
+  ]
+}

--- a/packages/satysfi-fonts-new-computer-modern/satysfi-fonts-new-computer-modern.7.1.1/opam
+++ b/packages/satysfi-fonts-new-computer-modern/satysfi-fonts-new-computer-modern.7.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SATySFi Font Package for New Computer Modern"
+description: """
+SATySFi Font Package for New Computer Modern.
+
+This package installs fonts from https://download.gnu.org.ua/release/newcm.
+"""
+maintainer: "ghaaj <91141283+ghaaj@users.noreply.github.com>"
+authors: "ghaaj <91141283+ghaaj@users.noreply.github.com>"
+license: "GustFL v1 or later"
+homepage: "https://github.com/ghaaj/satysfi-fonts-new-computer-modern"
+dev-repo: "git+https://github.com/ghaaj/satysfi-fonts-new-computer-modern.git"
+bug-reports: "https://github.com/ghaaj/satysfi-fonts-new-computer-modern/issues"
+extra-source "newcm-7.1.1.txz" {
+  archive: "https://download.gnu.org.ua/release/newcm/newcm-7.1.1.txz"
+  checksum: [
+    "sha256=27ba53922256ebb339a9b1e4e07252ee8e832738b4be6228e4adcaa9a9a76583"
+    "sha512=01d2578d1c2b0a4d5f035ad67370c91400b9463bec2a8c404b29df20d11c8553c37b17b9f1a87bc6aa76bb81c1206906dc23f1f7cc8c0781b7f5b9e992e2cb19"
+  ]
+}
+depends: [
+  "satysfi" { >= "0.0.10" }
+  "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+]
+build: [
+  ["tar" "Jxfv" "newcm-7.1.1.txz"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "fonts-new-computer-modern"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+url {
+  src:
+    "https://github.com/ghaaj/satysfi-fonts-new-computer-modern/archive/refs/tags/v7.1.1.tar.gz"
+  checksum: [
+    "md5=0cf4bf839cab9847ca72901203a1fd30"
+    "sha512=f6a1edd68155cee787590c185a105ead9b36e4fc22e96939a1d4d4a4e1f105c0462a6e2613d8152ef662b62cf0fb359ec3ecaa884b819f254bc4a29544876c07"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `satysfi-fonts-new-computer-modern.7.1.1`: SATySFi Font Package for New Computer
  Modern
- `satysfi-fonts-new-computer-modern-doc.7.1.1`: Document of SATySFi Font Package
  for New Computer Modern



---
* Homepage: https://github.com/ghaaj/satysfi-fonts-new-computer-modern
* Source repo: git+https://github.com/ghaaj/satysfi-fonts-new-computer-modern.git
* Bug tracker: https://github.com/ghaaj/satysfi-fonts-new-computer-modern/issues

---
:camel: Pull-request generated by opam-publish v3.0.0
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- [x] Add to snapshot `snapshot-develop` :: satysfi-fonts-new-computer-modern-doc.7.1.1 satysfi-fonts-new-computer-modern.7.1.1
- [x] Add to snapshot `snapshot-stable-0-0-10` :: satysfi-fonts-new-computer-modern-doc.7.1.1 satysfi-fonts-new-computer-modern.7.1.1
- [x] Add to snapshot `snapshot-stable-0-0-11` :: satysfi-fonts-new-computer-modern-doc.7.1.1 satysfi-fonts-new-computer-modern.7.1.1
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (Inconsistent)