### PR TITLE
Add archive mirror for New Computer Modern font

### DIFF
--- a/packages/satysfi-fonts-new-computer-modern/satysfi-fonts-new-computer-modern.7.1.1/opam
+++ b/packages/satysfi-fonts-new-computer-modern/satysfi-fonts-new-computer-modern.7.1.1/opam
@@ -13,6 +13,9 @@ dev-repo: "git+https://github.com/ghaaj/satysfi-fonts-new-computer-modern.git"
 bug-reports: "https://github.com/ghaaj/satysfi-fonts-new-computer-modern/issues"
 extra-source "newcm-7.1.1.txz" {
   archive: "https://download.gnu.org.ua/release/newcm/newcm-7.1.1.txz"
+  mirrors: [
+    "https://raw.githubusercontent.com/na4zagin3/satysfi-dist-font-archives/8717b6b3afb8d82f400905a797533d8a1b9c04fb/NewComputerModern/7.1.1/newcm-7.1.1.txz"
+  ]
   checksum: [
     "sha256=27ba53922256ebb339a9b1e4e07252ee8e832738b4be6228e4adcaa9a9a76583"
     "sha512=01d2578d1c2b0a4d5f035ad67370c91400b9463bec2a8c404b29df20d11c8553c37b17b9f1a87bc6aa76bb81c1206906dc23f1f7cc8c0781b7f5b9e992e2cb19"


### PR DESCRIPTION
Adds the satysfi-dist-font-archives copy of newcm-7.1.1.txz as an opam mirror for satysfi-fonts-new-computer-modern. The upstream versioned URL remains primary; the archive copy is a fallback for availability.\n\nVerification:\n- opam lint --color=never --strict for new-computer-modern package/doc package\n- git diff --check\n- downloaded raw mirror URL and verified existing sha256/sha512 checksums\n\nNote: opam lint still reports the existing non-SPDX warning for license `GustFL v1 or later`; this PR does not change that metadata.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-10`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-11`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (Inconsistent)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (Inconsistent)