### PR TITLE
Fix follow-up workflow reviewer assignment

### DIFF
--- a/.github/workflows/pr-followup.yaml
+++ b/.github/workflows/pr-followup.yaml
@@ -65,6 +65,5 @@ jobs:
             automated pr
 #          assignees: na4zagin3
 #          reviewers: na4zagin3
-          team-reviewers: |
-            owners
-            maintainers
+          # This repository is under a user account, so organization team reviewers
+          # are not valid and would make the workflow fail after creating the PR.


### PR DESCRIPTION
Remove invalid organization team reviewer requests from the post-merge follow-up workflow.

The current workflow successfully creates the follow-up PR and then fails when it tries to request the owners and maintainers team reviewers, which are not valid collaborators for this personal repository.

This change keeps the snapshot follow-up behavior but prevents the workflow from failing after PR creation.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-10`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-11`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)