### PR TITLE
Tame update-develop automation

### DIFF
--- a/.github/workflows/ci-comment.yaml
+++ b/.github/workflows/ci-comment.yaml
@@ -159,6 +159,7 @@ jobs:
             }
             
             const comments = [
+              '<!-- satyrographos-ci-summary -->',
               '# CI Summary'
             ];
             for (snapshot of snapshots) {
@@ -168,10 +169,32 @@ jobs:
               }
             }
             if (comments.length) {
-              await github.rest.issues.createComment({
+              const body = comments.join('\n');
+              const issueComments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pull_number,
-                body: comments.join('\n')
+                per_page: 100
               });
+              const existingComment = issueComments.data.find((comment) =>
+                comment.user &&
+                comment.user.type === 'Bot' &&
+                comment.body &&
+                comment.body.includes('<!-- satyrographos-ci-summary -->')
+              );
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pull_number,
+                  body
+                });
+              }
             }

--- a/.github/workflows/update-develop.yaml
+++ b/.github/workflows/update-develop.yaml
@@ -1,6 +1,7 @@
 name: Update SATySFi Dev Flow
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '52 15 * * *'
 


### PR DESCRIPTION
This addresses the two problems around #680.

Changes:
- make the CI summary comment idempotent by updating a single bot comment instead of creating a new issue comment on every successful CI run;
- add `workflow_dispatch` to `Update SATySFi Dev Flow` so the updater can be run manually if GitHub disables the schedule again.

Why:
- PR #680 stayed open while `update-develop-snapshot` was force-pushed repeatedly as SATySFi develop advanced;
- `CI Comment` appended a fresh `# CI Summary` on each run, which made the thread grow without bound;
- the scheduled updater workflow is currently `disabled_inactivity`, so having a manual trigger gives an immediate recovery path after re-enabling it.
# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-10`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-11`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)