### PR TITLE
Handle opam 2.2 integrity workaround in CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -21,7 +21,7 @@ SUCCEEDED_PACKAGES=succeeded.pkgs
 : > "$SUCCEEDED_PACKAGES"
 
 case "$(opam --version)" in
-    2.0.*|2.1.*)
+    2.0.*|2.1.*|2.2.*)
         echo "Enable workaround for OPAM Bug #5132"
         WORKAROUND_OPAM_BUG_5132=1
         echo "Enable workaround for #655"


### PR DESCRIPTION
CI for the refreshed develop snapshot PR (#680) is currently red in the develop lanes because `ci.sh` still only enables the OPAM integrity workaround for opam 2.0/2.1.

On the current GitHub runners, the failing jobs are running against opam 2.2 state and hit the same file-tracking issue after uninstall, ending with:

- `OPAM misdetected file creation as modification`

This change extends the existing workaround gate to opam 2.2 as well, which matches the observed runner behavior and keeps the CI consistent with the existing bug-compatibility intent in `ci.sh`.

This is separate from the update-develop automation fix already merged in #700.

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-10`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-11`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)