### PR TITLE
Generalize OPAM 2.x integrity workaround

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -21,7 +21,7 @@ SUCCEEDED_PACKAGES=succeeded.pkgs
 : > "$SUCCEEDED_PACKAGES"
 
 case "$(opam --version)" in
-    2.0.*|2.1.*|2.2.*)
+    2.*)
         echo "Enable workaround for OPAM Bug #5132"
         WORKAROUND_OPAM_BUG_5132=1
         echo "Enable workaround for #655"


### PR DESCRIPTION
## Summary
- broaden the existing OPAM integrity workaround from specific minor versions to all OPAM 2.x releases
- keep the current CI behavior stable on newer GitHub Actions runners

## Why
Recent reruns of #680 still fail in the develop lanes with `OPAM misdetected file creation as modification`. The previous fix for OPAM 2.2 was too narrow: the current runner's opam version no longer matches that case pattern, so the workaround is skipped even though the failure persists.

## Testing
- bash -n ci.sh
- git diff --check

# Automatic follow-ups
Choose follow-up actions.  Do not write anything after this section.
- ~~Add to snapshot `snapshot-develop`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-10`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-11`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-4`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-5`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-6--1`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-7`~~ (No updates)
- ~~Add to snapshot `snapshot-stable-0-0-8`~~ (No updates)